### PR TITLE
Mixpanel : Update the payload + add missing action

### DIFF
--- a/lib/services/events/analyzers/mixpanel.js
+++ b/lib/services/events/analyzers/mixpanel.js
@@ -18,8 +18,10 @@ module.exports = options => {
 
 Analyzer.prototype = {
 	prepare(payload) {
+		payload = payload.attributes;
 		const statsPackage = {
 			/*eslint-disable */
+			'action': payload.action,
 			'distinct_id': payload.distinctId,
 			'platform_id': payload.platform,
 			'channel_id': payload.channel,


### PR DESCRIPTION
I have Mixpanel working with this small change, setting the payload to start at `payload.attributes`, and adding the `action` missing in the statsPackage