### PR TITLE
fixes #54 - Update the payload + add missing send

### DIFF
--- a/lib/services/events/analyzers/google-analytics.js
+++ b/lib/services/events/analyzers/google-analytics.js
@@ -18,6 +18,7 @@ module.exports = options => {
 
 Analyzer.prototype = {
 	prepare(payload) {
+		payload = payload.attributes;
 		const visitor = ua(this.options.trackingId, payload.sessionId, {https: true, strictCidFormat: false});
 		const action = payload.action.split(':');
 		let screen;
@@ -46,7 +47,7 @@ Analyzer.prototype = {
 		payload = this.prepare(payload);
 
 		if (payload) {
-			payload.visitor.event(payload.params);
+			payload.visitor.event(payload.params).send();
 		}
 	}
 };


### PR DESCRIPTION
This fixes #54 - Updating the payload to use `payload.attributes` and adding the missing send() command to `payload.visitor.event(payload.params).send();` works as basic event tracking. SDKs now needs to be updated to include more information about the user's device. 

 