### PR TITLE
Fix a couple prototype assignments in utils.

### DIFF
--- a/lib/services/utils.js
+++ b/lib/services/utils.js
@@ -14,10 +14,10 @@ function initializer(bus, config) {
 	return config.service.initialize(bus, config.options);
 }
 
-ServicesUtils.prototype = {
+Object.assign(ServicesUtils.prototype, {
 	load(bus, serviceConfigurations) {
 		return Promise.all(_.map(serviceConfigurations, config => initializer(bus, config)));
 	}
-};
+});
 
 module.exports = exports = new ServicesUtils();

--- a/lib/stores/utils.js
+++ b/lib/stores/utils.js
@@ -14,10 +14,10 @@ function initializer(bus, config) {
 	return config.store.initialize(bus, config.options);
 }
 
-StoresUtils.prototype = {
+Object.assign(StoresUtils.prototype, {
 	load(bus, storeConfigurations) {
 		return Promise.all(_.map(storeConfigurations, config => initializer(bus, config)));
 	}
-};
+});
 
 module.exports = exports = new StoresUtils();


### PR DESCRIPTION
FooConstructor.prototype should not be assigned to, since that overrides
the global Object.prototype. Instead, Object.assign or _.exetend are
good alternatives.

	modified:   lib/services/utils.js
	modified:   lib/stores/utils.js