### PR TITLE
Partial getters setters

### DIFF
--- a/lib/services/utils.js
+++ b/lib/services/utils.js
@@ -14,10 +14,10 @@ function initializer(bus, config) {
 	return config.service.initialize(bus, config.options);
 }
 
-ServicesUtils.prototype = {
+Object.assign(ServicesUtils.prototype, {
 	load(bus, serviceConfigurations) {
 		return Promise.all(_.map(serviceConfigurations, config => initializer(bus, config)));
 	}
-};
+});
 
 module.exports = exports = new ServicesUtils();

--- a/lib/stores/memory/index.js
+++ b/lib/stores/memory/index.js
@@ -9,42 +9,41 @@ const store = exports = module.exports = {};
 let STORE = {};
 
 store.initialize = (bus, options) => {
-	return new Promise((resolve, reject) => {
-		if (options.types) {
-			options.types.forEach(type => {
-				bus.queryHandler({role: 'store', cmd: 'get', type: type}, get);
-				bus.queryHandler({role: 'store', cmd: 'set', type: type}, set);
-				bus.commandHandler({role: 'store', cmd: 'set', type: type}, set);
-			});
+	if (options.types) {
+		options.types.forEach(type => {
+			bus.queryHandler({role: 'store', cmd: 'get', type: type}, get);
+			bus.queryHandler({role: 'store', cmd: 'set', type: type}, set);
+			bus.commandHandler({role: 'store', cmd: 'set', type: type}, set);
+		});
 
-			resolve(true);
-		} else {
-			reject(new Error('options.types is missing'));
-		}
-	});
+		return Promise.resolve(true);
+	}
+
+	return Promise.reject(new Error('options.types is missing'));
 };
 
 function get(payload) {
-	return new Promise((resolve, reject) => {
-		if (!payload.type) {
-			return reject(new Error('payload.type is require'));
-		}
+	if (!payload.type) {
+		return Promise.reject(new Error('payload.type is require'));
+	}
 
-		if (payload.id) {
-			return resolve(STORE[payload.type][payload.id]);
-		}
+	if (payload.id) {
+		return Promise.resolve(STORE[payload.type][payload.id]);
+	}
 
-		return resolve(_.toArray(STORE[payload.type]));
-	});
+	return Promise.resolve(_.toArray(STORE[payload.type]));
 }
 
 function set(payload) {
-	return new Promise(resolve => {
-		payload.id = payload.id || uuid.v4();
-		STORE[payload.type] = STORE[payload.type] || {};
-		STORE[payload.type][payload.id] = payload;
-		return resolve(payload);
-	});
+	// Make a copy to prevent unintended mutation.
+	payload = _.cloneDeep(payload);
+	payload.id = payload.id || uuid.v4();
+
+	// Create the store "table" Object if it does not exist.
+	STORE[payload.type] = STORE[payload.type] || {};
+
+	STORE[payload.type][payload.id] = payload;
+	return Promise.resolve(payload);
 }
 
 store.name = 'catalog';

--- a/lib/stores/memory/index.js
+++ b/lib/stores/memory/index.js
@@ -11,9 +11,9 @@ let STORE = {};
 store.initialize = (bus, options) => {
 	if (options.types) {
 		options.types.forEach(type => {
-			bus.queryHandler({role: 'store', cmd: 'get', type: type}, get);
-			bus.queryHandler({role: 'store', cmd: 'set', type: type}, set);
-			bus.commandHandler({role: 'store', cmd: 'set', type: type}, set);
+			bus.queryHandler({role: 'store', cmd: 'get', type}, createGetter(type));
+			bus.queryHandler({role: 'store', cmd: 'set', type}, createSetter(type));
+			bus.commandHandler({role: 'store', cmd: 'set', type}, createSetter(type));
 		});
 
 		return Promise.resolve(true);
@@ -22,28 +22,28 @@ store.initialize = (bus, options) => {
 	return Promise.reject(new Error('options.types is missing'));
 };
 
-function get(payload) {
-	if (!payload.type) {
-		return Promise.reject(new Error('payload.type is require'));
-	}
+function createGetter(type) {
+	return function get(payload) {
+		if (payload.id) {
+			return Promise.resolve(STORE[type][payload.id]);
+		}
 
-	if (payload.id) {
-		return Promise.resolve(STORE[payload.type][payload.id]);
-	}
-
-	return Promise.resolve(_.toArray(STORE[payload.type]));
+		return Promise.resolve(_.toArray(STORE[type]));
+	};
 }
 
-function set(payload) {
-	// Make a copy to prevent unintended mutation.
-	payload = _.cloneDeep(payload);
-	payload.id = payload.id || uuid.v4();
+function createSetter(type) {
+	return function set(payload) {
+		// Make a copy to prevent unintended mutation.
+		payload = _.cloneDeep(payload);
+		payload.id = payload.id || uuid.v4();
 
-	// Create the store "table" Object if it does not exist.
-	STORE[payload.type] = STORE[payload.type] || {};
+		// Create the store "table" Object if it does not exist.
+		STORE[type] = STORE[type] || Object.create(null);
 
-	STORE[payload.type][payload.id] = payload;
-	return Promise.resolve(payload);
+		STORE[type][payload.id] = payload;
+		return Promise.resolve(payload);
+	};
 }
 
 store.name = 'catalog';

--- a/lib/stores/redis-search/index.js
+++ b/lib/stores/redis-search/index.js
@@ -15,18 +15,16 @@ store.initialize = (bus, options) => {
 		config.options.search = Search.createSearch({client: config.options.redis});
 	}
 
-	return new Promise((resolve, reject) => {
-		if (config.options.types) {
-			config.options.types.forEach(type => {
-				config.bus.commandHandler({role: 'store', cmd: 'index', type}, index);
-			});
-			config.bus.queryHandler({role: 'store', cmd: 'query'}, query);
+	if (config.options.types) {
+		config.options.types.forEach(type => {
+			config.bus.commandHandler({role: 'store', cmd: 'index', type}, index);
+		});
+		config.bus.queryHandler({role: 'store', cmd: 'query'}, query);
 
-			resolve(true);
-		} else {
-			reject(new Error('options.types is missing'));
-		}
-	});
+		return Promise.resolve(true);
+	}
+
+	return Promise.reject(new Error('options.types is missing'));
 };
 
 function index(payload) {

--- a/lib/stores/redis/index.js
+++ b/lib/stores/redis/index.js
@@ -13,53 +13,50 @@ store.initialize = (bus, options) => {
 
 	Promise.promisifyAll(config.options.redis);
 
-	return new Promise((resolve, reject) => {
-		if (config.options.types) {
-			config.options.types.forEach(type => {
-				config.bus.queryHandler({role: 'store', cmd: 'get', type}, get);
-				config.bus.queryHandler({role: 'store', cmd: 'set', type}, set);
-				config.bus.commandHandler({role: 'store', cmd: 'set', type}, set);
-			});
+	if (config.options.types) {
+		config.options.types.forEach(type => {
+			config.bus.queryHandler({role: 'store', cmd: 'get', type}, get);
+			config.bus.queryHandler({role: 'store', cmd: 'set', type}, set);
+			config.bus.commandHandler({role: 'store', cmd: 'set', type}, set);
+		});
 
-			resolve(true);
-		} else {
-			reject(new Error('options.types is missing'));
-		}
-	});
+		return Promise.resolve(true);
+	}
+
+	return Promise.reject(new Error('options.types is missing'));
 };
 
 function get(payload) {
-	return new Promise((resolve, reject) => {
-		if (!payload.type) {
-			return reject(new Error('payload.type is require'));
-		}
+	if (!payload.type) {
+		return Promise.reject(new Error('payload.type is require'));
+	}
 
-		if (payload.id) {
-			return config.options.redis
-				.hgetAsync(payload.type, payload.id)
-				.then(object => resolve(JSON.parse(object)))
-				.catch(err => reject(err));
-		}
-
+	if (payload.id) {
 		return config.options.redis
-			.hgetallAsync(payload.type)
-			.then(objects => {
-				objects = _.map(_.toArray(objects), object => {
-					return JSON.parse(object);
-				});
-				return resolve(objects);
-			})
-			.catch(err => reject(err));
-	});
+			.hgetAsync(payload.type, payload.id)
+			.then(object => {
+				return JSON.parse(object);
+			});
+	}
+
+	return config.options.redis
+		.hgetallAsync(payload.type)
+		.then(objects => {
+			return _.map(_.toArray(objects), object => {
+				return JSON.parse(object);
+			});
+		});
 }
 
 function set(payload) {
-	return new Promise((resolve, reject) => {
-		payload.id = payload.id || uuid.v4();
-		config.options.redis.hsetAsync(payload.type, payload.id, JSON.stringify(payload))
-			.then(() => resolve(payload))
-			.catch(err => reject(err));
-	});
+	// Make a copy to prevent unintended mutation.
+	payload = _.cloneDeep(payload);
+	payload.id = payload.id || uuid.v4();
+
+	return config.options.redis.hsetAsync(payload.type, payload.id, JSON.stringify(payload))
+		.then(() => {
+			return payload;
+		});
 }
 
 store.name = 'redis';

--- a/lib/stores/redis/index.js
+++ b/lib/stores/redis/index.js
@@ -15,9 +15,9 @@ store.initialize = (bus, options) => {
 
 	if (config.options.types) {
 		config.options.types.forEach(type => {
-			config.bus.queryHandler({role: 'store', cmd: 'get', type}, get);
-			config.bus.queryHandler({role: 'store', cmd: 'set', type}, set);
-			config.bus.commandHandler({role: 'store', cmd: 'set', type}, set);
+			config.bus.queryHandler({role: 'store', cmd: 'get', type}, createGetter(type));
+			config.bus.queryHandler({role: 'store', cmd: 'set', type}, createSetter(type));
+			config.bus.commandHandler({role: 'store', cmd: 'set', type}, createSetter(type));
 		});
 
 		return Promise.resolve(true);
@@ -26,37 +26,37 @@ store.initialize = (bus, options) => {
 	return Promise.reject(new Error('options.types is missing'));
 };
 
-function get(payload) {
-	if (!payload.type) {
-		return Promise.reject(new Error('payload.type is require'));
-	}
+function createGetter(type) {
+	return function get(payload) {
+		if (payload.id) {
+			return config.options.redis
+				.hgetAsync(type, payload.id)
+				.then(object => {
+					return JSON.parse(object);
+				});
+		}
 
-	if (payload.id) {
 		return config.options.redis
-			.hgetAsync(payload.type, payload.id)
-			.then(object => {
-				return JSON.parse(object);
+			.hgetallAsync(type)
+			.then(objects => {
+				return _.map(_.toArray(objects), object => {
+					return JSON.parse(object);
+				});
 			});
-	}
-
-	return config.options.redis
-		.hgetallAsync(payload.type)
-		.then(objects => {
-			return _.map(_.toArray(objects), object => {
-				return JSON.parse(object);
-			});
-		});
+	};
 }
 
-function set(payload) {
-	// Make a copy to prevent unintended mutation.
-	payload = _.cloneDeep(payload);
-	payload.id = payload.id || uuid.v4();
+function createSetter(type) {
+	return function set(payload) {
+		// Make a copy to prevent unintended mutation.
+		payload = _.cloneDeep(payload);
+		payload.id = payload.id || uuid.v4();
 
-	return config.options.redis.hsetAsync(payload.type, payload.id, JSON.stringify(payload))
-		.then(() => {
-			return payload;
-		});
+		return config.options.redis.hsetAsync(type, payload.id, JSON.stringify(payload))
+			.then(() => {
+				return payload;
+			});
+	};
 }
 
 store.name = 'redis';

--- a/lib/stores/utils.js
+++ b/lib/stores/utils.js
@@ -14,10 +14,10 @@ function initializer(bus, config) {
 	return config.store.initialize(bus, config.options);
 }
 
-StoresUtils.prototype = {
+Object.assign(StoresUtils.prototype, {
 	load(bus, storeConfigurations) {
 		return Promise.all(_.map(storeConfigurations, config => initializer(bus, config)));
 	}
-};
+});
 
 module.exports = exports = new StoresUtils();


### PR DESCRIPTION
By using partials as factories to create getter and setter methods on stores, we can eliminate the requirement to pass in an entity type when creating or querying for it.