### PR TITLE
Protect options hashes passed into services

### DIFF
--- a/lib/services/catalog/index.js
+++ b/lib/services/catalog/index.js
@@ -101,6 +101,7 @@ service.initialize = (bus, options) => {
 };
 
 service.router = options => {
+	options = options || {};
 	const types = options.types || ['collection', 'promotion', 'video', 'view'];
 
 	types.forEach(type => {

--- a/lib/services/events/index.js
+++ b/lib/services/events/index.js
@@ -27,6 +27,7 @@ service.initialize = (bus, options) => {
 };
 
 service.router = options => {
+	options = options || {};
 	router.post(`/events`, (req, res, next) => {
 		config.bus.broadcast({role: 'events'}, req.body);
 

--- a/lib/services/identity/index.js
+++ b/lib/services/identity/index.js
@@ -14,8 +14,8 @@ const service = exports = module.exports = {};
 service.name = 'identity';
 
 service.initialize = (bus, options) => {
-	service.bus = bus;
 	service.options = options || {};
+	service.bus = bus;
 
 	service.bus.queryHandler({role: 'identity', cmd: 'verify'}, payload => {
 		return new Promise((resolve, reject) => {
@@ -103,6 +103,7 @@ service.middleware = {
 	},
 
 	authenticateUser(options) {
+		options = options || {};
 		return (req, res, next) => {
 			const token = req.get(options.header);
 			if (token) {
@@ -120,7 +121,8 @@ service.middleware = {
 	}
 };
 
-service.router = options => { // eslint-disable-line
+service.router = options => {
+	options = options || {};
 	router.get('/config', (req, res, next) => {
 		service.bus
 			.query({role: 'identity', cmd: 'config'}, {channel: req.identity.channel.id, platform: req.identity.platform.id})


### PR DESCRIPTION
Avoids reference errors passing options hash Object into service router setup
functions. This allows callers to call the setup functions without any
options.

	modified:   lib/services/catalog/index.js
	modified:   lib/services/events/index.js
	modified:   lib/services/identity/index.js