### PR TITLE
Removes confusion as redis is unnecessary

### DIFF
--- a/lib/services/events/README.md
+++ b/lib/services/events/README.md
@@ -6,7 +6,6 @@ Acts as a proxy to send event data off to 3rd party analytics services.
 
 **Options**
 
-* `redis` - the instance of Redis used to store events for later aggregation
 * `analyzers` - array of [analyzers](/analyzers) that will be sent event payloads
 
 ## Patterns
@@ -27,7 +26,6 @@ Right now there is official support for 2 analyzers. However, you can implement 
 
 ```js
 eventsService.initialize(bus, {
-	redis,
 	analyzers: [
 		eventsService.analyzers.googleAnalytics({trackingId: process.env.GA_TRACKING_ID})
 	]
@@ -52,7 +50,6 @@ eventsService.initialize(bus, {
 
 ```js
 eventsService.initialize(bus, {
-	redis,
 	analyzers: [
 		eventsService.analyzers.mixpanel({apiKey: process.env.MIXPANEL_API_KEY, timeMultiplier: 1000})
 	]

--- a/test/support/test-config.js
+++ b/test/support/test-config.js
@@ -83,12 +83,9 @@ module.exports = {
 		{
 			service: eventsService,
 			options: {
-				redis,
 				analyzers: [
-					/* eslint-disable */
 					eventsService.analyzers.googleAnalytics({trackingId: process.env.GA_TRACKING_ID}),
 					eventsService.analyzers.mixpanel({apiKey: process.env.MIXPANEL_API_KEY, timeMultiplier: 1000})
-					/* eslint-enable */
 				]
 			}
 		}


### PR DESCRIPTION
AFAIK, redis isn't necessary as a configuration option for the events analyzers. If we are going to store events for later, we should probably do it with either a new analyzer or use our oddcast store pattern.