### PR TITLE
Moves the middleware defined in the identity service

### DIFF
--- a/lib/middleware/index.js
+++ b/lib/middleware/index.js
@@ -15,6 +15,8 @@ const MIDDLEWARE = {
 	},
 	'error-handler': require('./error-handler'),
 	'request-accept': require('./request-accept'),
+	'request-authenticate': require('./request-authenticate'),
+	'request-authorize': require('./request-authorize'),
 	'request-json-api': require('./request-json-api'),
 	'request-options': require('./request-options'),
 	'response-cache-control': require('./response-cache-control'),

--- a/lib/middleware/request-authenticate.js
+++ b/lib/middleware/request-authenticate.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const _ = require('lodash');
+const debug = require('debug')('oddworks:middleware:authenticate');
+const Boom = require('boom');
+
+// options.bus - Oddcast Bus instance *required*
+// options.header - HTTP header to look for the JWT *default=Authorization*
+module.exports = function (options) {
+	options = _.defaults({}, options, {
+		header: 'Authorization'
+	});
+
+	if (!options.bus || !_.isObject(options.bus)) {
+		throw new Error('The options.bus Object is required.');
+	}
+
+	const bus = options.bus;
+	const header = options.header;
+
+	return function authenticateMiddleware(req, res, next) {
+		// Parse out the Authorization header if used.
+		// ex: "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJh..."
+		debug('using the %s header', header);
+		const headerValue = (req.get(header) || '').split(/[\s]+/);
+		const token = headerValue.length > 1 ? headerValue[1] : headerValue[0];
+
+		if (token) {
+			debug('using token %s', token);
+			bus
+				.query({role: 'identity', cmd: 'verify'}, {token})
+				.then(identity => {
+					req.identity = identity;
+					next();
+					return null;
+				})
+				.catch(err => {
+					debug('invalid-access-token: %s', err.message);
+					bus.broadcast(
+						{level: 'warn', event: 'invalid-access-token'},
+						{message: err.message, error: err}
+					);
+					next(Boom.unauthorized('Invalid Access Token'));
+					return null;
+				});
+		} else {
+			debug('missing-access-token');
+			bus.broadcast(
+				{level: 'info', event: 'missing-access-token'},
+				{message: 'Missing Access Token'}
+			);
+			next(Boom.unauthorized('Missing Access Token'));
+		}
+	};
+};

--- a/lib/middleware/request-authorize.js
+++ b/lib/middleware/request-authorize.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const _ = require('lodash');
+const debug = require('debug')('oddworks:middleware:authorize');
+const Boom = require('boom');
+
+module.exports = function (options) {
+	options = _.defaults({}, options, {
+		audience: Object.create(null)
+	});
+
+	if (!options.bus || !_.isObject(options.bus)) {
+		throw new Error('The options.bus Object is required.');
+	}
+
+	const bus = options.bus;
+	const whiteList = options.audience;
+
+	return function authorizeMiddleware(req, res, next) {
+		let audience = (req.identity || {}).audience;
+		if (!audience) {
+			debug('invalid-access-token: Missing token audience claim.');
+			bus.broadcast(
+				{level: 'warn', event: 'invalid-access-token'},
+				{message: 'Missing token audience claim'}
+			);
+			next(Boom.unauthorized('Missing Token audience claim'));
+		}
+
+		audience = Array.isArray(audience) ? audience : [audience];
+
+		const method = req.method.toLowerCase();
+		const allowed = whiteList[method];
+		debug('method: %s', method);
+		debug('audience: %s', audience.join());
+		debug('allowed: %s', allowed.join());
+		if (!allowed) {
+			return next(Boom.methodNotAllowed());
+		}
+
+		let i;
+		for (i = 0; i < allowed.length; i += 1) {
+			if (audience.indexOf(allowed[i]) >= 0) {
+				return next();
+			}
+		}
+
+		next(Boom.forbidden(
+			`${req.method} access not permitted to this resource`
+		));
+	};
+};

--- a/lib/services/catalog/index.js
+++ b/lib/services/catalog/index.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const express = require('express');
 
+const middleware = require('../../middleware');
 const initializeQueries = require('./queries/');
 const initializeCommands = require('./commands/');
 const CatalogItemController = require('./controllers/catalog-item-controller');
@@ -119,7 +120,7 @@ module.exports = function (bus, options) {
 		types.forEach(type => {
 			router.all(
 				`/${type}s`,
-				bus.query({middleware: 'authorize'}, {bus, audience: {
+				middleware['request-authorize']({bus, audience: {
 					get: ['admin', 'platform'],
 					post: ['admin'],
 					delete: ['admin']
@@ -129,7 +130,7 @@ module.exports = function (bus, options) {
 
 			router.all(
 				`/${type}s/:id`,
-				bus.query({middleware: 'authorize'}, {bus, audience: {
+				middleware['request-authorize']({bus, audience: {
 					get: ['admin', 'platform'],
 					patch: ['admin'],
 					delete: ['admin']
@@ -138,12 +139,18 @@ module.exports = function (bus, options) {
 			);
 		});
 
-		router.all('/search', CatalogSearchController.create({bus}));
+		router.all(
+			'/search',
+			middleware['request-authorize']({bus, audience: {
+				get: ['platform']
+			}}),
+			CatalogSearchController.create({bus})
+		);
 
 		specTypes.forEach(type => {
 			router.all(
 				`/${type}s`,
-				bus.query({middleware: 'authorize'}, {bus, audience: {
+				middleware['request-authorize']({bus, audience: {
 					get: ['admin'],
 					post: ['admin'],
 					delete: ['admin']
@@ -153,7 +160,7 @@ module.exports = function (bus, options) {
 
 			router.all(
 				`/${type}s/:id`,
-				bus.query({middleware: 'authorize'}, {bus, audience: {
+				middleware['request-authorize']({bus, audience: {
 					get: ['admin'],
 					patch: ['admin'],
 					delete: ['admin']

--- a/lib/services/identity/index.js
+++ b/lib/services/identity/index.js
@@ -2,14 +2,15 @@
 
 const _ = require('lodash');
 const express = require('express');
-const Boom = require('boom');
-const debug = require('debug');
+const debug = require('debug')('oddworks:identity-service');
+const middleware = require('../../middleware');
 const initializeQueries = require('./queries/');
 const IdentityItemController = require('./controllers/identity-item-controller');
 const IdentityListController = require('./controllers/identity-list-controller');
 const IdentityConfigController = require('./controllers/identity-config-controller');
 
 module.exports = function (bus, options) {
+	debug('initializing');
 	if (!bus || !_.isObject(bus)) {
 		throw new Error('The bus must be the first argument.');
 	}
@@ -53,108 +54,8 @@ module.exports = function (bus, options) {
 		queries.composeConfig
 	);
 
-	service.middleware = {
-		// options.header - String default=Authorization
-		authenticate(options) {
-			const log = debug('oddworks:middleware:authenticate');
-			options = _.defaults({}, options, {
-				header: 'Authorization'
-			});
-
-			const header = options.header;
-			log('using the %s header', header);
-
-			return function authenticateMiddleware(req, res, next) {
-				// Parse out the Authorization header if used.
-				// ex: "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJh..."
-				const headerValue = (req.get(header) || '').split(/[\s]+/);
-				const token = headerValue.length > 1 ? headerValue[1] : headerValue[0];
-
-				if (token) {
-					log('using token %s', token);
-					bus
-						.query({role: 'identity', cmd: 'verify'}, {token})
-						.then(identity => {
-							req.identity = identity;
-							next();
-							return null;
-						})
-						.catch(err => {
-							log('invalid-access-token: %s', err.message);
-							bus.broadcast(
-								{level: 'warn', event: 'invalid-access-token'},
-								{message: err.message, error: err}
-							);
-							next(Boom.unauthorized('Invalid Access Token'));
-							return null;
-						});
-				} else {
-					log('missing-access-token');
-					bus.broadcast(
-						{level: 'info', event: 'missing-access-token'},
-						{message: 'Missing Access Token'}
-					);
-					next(Boom.unauthorized('Missing Access Token'));
-				}
-			};
-		},
-
-		// options.audience - Object
-		authorize(options) {
-			const log = debug('oddworks:middleware:authorize');
-			options = _.defaults({}, options, {
-				audience: Object.create(null)
-			});
-
-			const whiteList = options.audience;
-
-			return function authorizeMiddleware(req, res, next) {
-				let audience = (req.identity || {}).audience;
-				if (!audience) {
-					log('invalid-access-token: Missing token audience claim.');
-					bus.broadcast(
-						{level: 'warn', event: 'invalid-access-token'},
-						{message: 'Missing token audience claim'}
-					);
-					next(Boom.unauthorized('Missing Token audience claim'));
-				}
-
-				audience = Array.isArray(audience) ? audience : [audience];
-
-				const method = req.method.toLowerCase();
-				const allowed = whiteList[method];
-				log('method: %s', method);
-				log('audience: %s', audience.join());
-				log('allowed: %s', allowed.join());
-				if (!allowed) {
-					return next(Boom.methodNotAllowed());
-				}
-
-				let i;
-				for (i = 0; i < allowed.length; i += 1) {
-					if (audience.indexOf(allowed[i]) >= 0) {
-						return next();
-					}
-				}
-
-				next(Boom.forbidden(
-					`${req.method} access not permitted to this resource`
-				));
-			};
-		}
-	};
-
-	bus.queryHandler(
-		{middleware: 'authenticate'},
-		service.middleware.authenticate
-	);
-
-	bus.queryHandler(
-		{middleware: 'authorize'},
-		service.middleware.authorize
-	);
-
 	service.router = function (options) {
+		debug('setting up routes');
 		options = _.defaults({}, options, {
 			types: ['channel', 'platform']
 		});
@@ -165,7 +66,7 @@ module.exports = function (bus, options) {
 		types.forEach(type => {
 			router.all(
 				`/${type}s`,
-				service.middleware.authorize({audience: {
+				middleware['request-authorize']({audience: {
 					get: ['admin'],
 					post: ['admin']
 				}}),
@@ -174,7 +75,7 @@ module.exports = function (bus, options) {
 
 			router.all(
 				`/${type}s/:id`,
-				service.middleware.authorize({audience: {
+				middleware['request-authorize']({audience: {
 					get: ['admin'],
 					patch: ['admin'],
 					delete: ['admin']
@@ -185,7 +86,7 @@ module.exports = function (bus, options) {
 
 		router.all(
 			'/config',
-			service.middleware.authorize({audience: {
+			middleware['request-authorize']({audience: {
 				get: ['platform', 'admin']
 			}}),
 			IdentityConfigController.create({bus})
@@ -194,5 +95,6 @@ module.exports = function (bus, options) {
 		return router;
 	};
 
+	debug('initialized');
 	return Promise.resolve(service);
 };


### PR DESCRIPTION
All middleware really belongs in the middleware library. Also, moving it
removed the hard dependency of the catalog on the identity service.

	modified:   lib/middleware/index.js
	new file:   lib/middleware/request-authenticate.js
	new file:   lib/middleware/request-authorize.js
	modified:   lib/services/catalog/index.js
	modified:   lib/services/identity/index.js