### PR TITLE
Surrogate Key Header

### DIFF
--- a/lib/middleware/response-cache-control.js
+++ b/lib/middleware/response-cache-control.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 
 module.exports = function (options) {
-	options = options || {};
+	options = options || {surrogateKey: false};
 
 	const header = [
 		'public',
@@ -14,6 +14,11 @@ module.exports = function (options) {
 
 	return function responseCacheControl(req, res, next) {
 		res.set('Cache-Control', header);
+
+		if (options.surrogateKey) {
+			res.set('Surrogate-Key', composeSurrogateKey(req, res));
+		}
+
 		next();
 	};
 };

--- a/lib/middleware/response-cache-control.js
+++ b/lib/middleware/response-cache-control.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const _ = require('lodash');
+
 module.exports = function (options) {
 	options = options || {};
 
@@ -15,3 +17,39 @@ module.exports = function (options) {
 		next();
 	};
 };
+
+function composeSurrogateKey(req, res) {
+	const channel = req.identity.channel.id;
+	const platform = req.identity.platform.id;
+
+	let surrogateKey = [
+		channel,
+		platform,
+		`${channel}:${platform}`
+	];
+
+	if (Array.isArray(res.body)) {
+		const ids = [];
+		const types = [];
+
+		_.each(res.body, item => {
+			ids.push(`${channel}:${item.id}`, `${channel}:${platform}:${item.id}`, item.id);
+			types.push(item.type);
+		});
+		surrogateKey = surrogateKey.concat(ids);
+		surrogateKey = surrogateKey.concat(
+			_(types)
+			.uniq()
+			.map(type => {
+				return [`${channel}:${type}`, `${channel}:${platform}:${type}`, type];
+			})
+			.flatten()
+			.value()
+		);
+	} else {
+		surrogateKey = surrogateKey.concat([`${channel}:${res.body.type}`, `${channel}:${platform}:${res.body.type}`, res.body.type]);
+		surrogateKey = surrogateKey.concat([`${channel}:${res.body.id}`, `${channel}:${platform}:${res.body.id}`, res.body.id]);
+	}
+
+	return surrogateKey.join(' ');
+}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "dynalite": "~1.0.0",
     "fakeredis": "~1.0.0",
     "jasmine": "~2.4.0",
+    "mock-express-request": "^0.1.1",
+    "mock-express-response": "^0.1.2",
     "nsp": "~2.4.0",
     "xo": "~0.15.0"
   },

--- a/spec/middleware/response-cache-control-spec.js
+++ b/spec/middleware/response-cache-control-spec.js
@@ -1,0 +1,85 @@
+/* global describe, beforeAll, it, expect */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint-disable max-nested-callbacks */
+'use strict';
+
+const MockExpressResponse = require('mock-express-response');
+
+const responseCacheControl = require('../../lib/middleware/response-cache-control');
+
+describe('Middleware: Response Cache Control', () => {
+	let req;
+	let res;
+
+	beforeAll(() => {
+		req = {
+			identity: {
+				channel: {id: 'channel-id'},
+				platform: {id: 'platform-id'}
+			}
+		};
+		res = new MockExpressResponse();
+	});
+
+	it('applies defaults', () => {
+		responseCacheControl()(req, res, () => {
+			expect(res.get('Cache-Control')).toBe('public, max-age=600, stale-while-revalidate=604800, stale-if-error=604800');
+		});
+	});
+
+	it('adds Surrogate Key header for single resource', () => {
+		res.body = {id: 'resource-id', type: 'resource-type'};
+
+		responseCacheControl({surrogateKey: true})(req, res, () => {
+			const surrogateKey = res.get('Surrogate-Key');
+
+			expect(surrogateKey.split(' ').length).toBe(9);
+
+			expect(surrogateKey).toMatch('channel-id');
+			expect(surrogateKey).toMatch('platform-id');
+			expect(surrogateKey).toMatch('channel-id:platform-id');
+
+			expect(surrogateKey).toMatch('resource-type');
+			expect(surrogateKey).toMatch('channel-id:resource-type');
+			expect(surrogateKey).toMatch('channel-id:platform-id:resource-type');
+
+			expect(surrogateKey).toMatch('resource-id');
+			expect(surrogateKey).toMatch('channel-id:resource-id');
+			expect(surrogateKey).toMatch('channel-id:platform-id:resource-id');
+		});
+	});
+
+	it('adds Surrogate Key header for listing resources', () => {
+		res.body = [
+			{id: 'resource-id-1', type: 'resource-type'},
+			{id: 'resource-id-2', type: 'resource-type'},
+			{id: 'resource-id-3', type: 'resource-type'}
+		];
+
+		responseCacheControl({surrogateKey: true})(req, res, () => {
+			const surrogateKey = res.get('Surrogate-Key');
+
+			expect(surrogateKey.split(' ').length).toBe(15);
+
+			expect(surrogateKey).toMatch('channel-id');
+			expect(surrogateKey).toMatch('platform-id');
+			expect(surrogateKey).toMatch('channel-id:platform-id');
+
+			expect(surrogateKey).toMatch('resource-type');
+			expect(surrogateKey).toMatch('channel-id:resource-type');
+			expect(surrogateKey).toMatch('channel-id:platform-id:resource-type');
+
+			expect(surrogateKey).toMatch('resource-id-1');
+			expect(surrogateKey).toMatch('channel-id:resource-id-1');
+			expect(surrogateKey).toMatch('channel-id:platform-id:resource-id-1');
+
+			expect(surrogateKey).toMatch('resource-id-2');
+			expect(surrogateKey).toMatch('channel-id:resource-id-2');
+			expect(surrogateKey).toMatch('channel-id:platform-id:resource-id-2');
+
+			expect(surrogateKey).toMatch('resource-id-3');
+			expect(surrogateKey).toMatch('channel-id:resource-id-3');
+			expect(surrogateKey).toMatch('channel-id:platform-id:resource-id-3');
+		});
+	});
+});


### PR DESCRIPTION
This will close #105 by adding the Fastly `Surrogate-Key` header for targeted cache invalidating.

**Single Resource Permutations**
- channel
- platform
- type
- id
- channel:platform
- channel:type
- channel:id
- channel:platform:type
- channel:platform:id


**Listing Resources Permutations**
- channel
- platform
- type{0..N} *unique*
- id{0..N}
- channel:platform
- channel:type{0..N} *unique*
- channel:id{0..N}
- channel:platform:type{0..N} *unique*
- channel:platform:id{0..N}

TODO: Support resources in `include` array too.