### PR TITLE
change 403 error to return 405 on bad method access

### DIFF
--- a/lib/middleware/request-authorize.js
+++ b/lib/middleware/request-authorize.js
@@ -45,7 +45,7 @@ module.exports = function (options) {
 			}
 		}
 
-		next(Boom.forbidden(
+		next(Boom.methodNotAllowed(
 			`${req.method} access not permitted to this resource`
 		));
 	};


### PR DESCRIPTION
Not sure this is required but as long as I spent an hour debugging an issue I'm posting it. If the true intent is 403 - Forbidden and not 405 - method not allowed feel free to delete this PR.