### PR TITLE
removes appending port to links in json responses for prod

### DIFF
--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -109,7 +109,7 @@ module.exports = function (options) {
 			defaultPort = true;
 		}
 
-		if (!defaultPort) {
+		if (!defaultPort && process.env.NODE_ENV && process.env.NODE_ENV.toUpperCase() !== 'PRODUCTION') {
 			baseUrl = `${baseUrl}:${port}`;
 		}
 		if (BASE_PREFIX) {


### PR DESCRIPTION
We are appending the port to any links in json api responses. This checks if we are running in production and omits appending the port if so. Allows running in prod on heroku.