### PR TITLE
allows channel creation when only auth token is defined

### DIFF
--- a/lib/middleware/request-authenticate.js
+++ b/lib/middleware/request-authenticate.js
@@ -30,13 +30,25 @@ module.exports = function (options) {
 			bus
 				.query({role: 'identity', cmd: 'verify'}, {token})
 				.then(identity => {
-					if (!identity.channel.active || !identity.platform.active) {
-						debug('invalid-access-token: channel or platform is active: false');
+					var okChannel = !identity.channel || identity.channel.active;
+					if(!okChannel){
+						debug('invalid-access: channel is not active');
 						bus.broadcast(
-							{level: 'warn', event: 'invalid-access-token'},
-							{message: 'channel or platform is active: false', error: null}
+							{level: 'warn', event: 'invalid-channel'},
+							{message: 'channel is active: false', error: null}
 						);
-						next(Boom.unauthorized('Invalid Access Token'));
+						next(Boom.unauthorized('Channel is not active'));
+						return null;
+					}					
+					
+					var okPlatform = !identity.platform || identity.platform.active;				
+					if (!okPlatform) {
+						debug('invalid-access: platform is not active');
+						bus.broadcast(
+							{level: 'warn', event: 'invalid-platform'},
+							{message: 'platform is active: false', error: null}
+						);
+						next(Boom.unauthorized('Platform is not active'));
 						return null;
 					}
 


### PR DESCRIPTION
This pull request:
- allows an api request that has a valid token, but zero channels or platforms, to create the channel or platform
- provides clearer error messages when there is an invalid platform or channel