### PR TITLE
Fix tests for 6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   - CXX=g++-4.8 DATA_DIR=./test/data
 node_js:
   - 'stable'
+  - '5'
   - '4'
 before_install:
   - sudo apt-get update

--- a/spec/helpers/setup.js
+++ b/spec/helpers/setup.js
@@ -20,19 +20,8 @@ const SETUP_TIMEOUT = 5000;
 MockServerResponse.prototype._getString = function () {
 	const buffs = this._readableState.buffer;
 
-	if (Array.isArray(buffs)) {
-		return buffs.map(buff => {
-			if (Buffer.isBuffer(buff)) {
-				return buff.toString('utf8');
-			} else if (typeof buff === 'string') {
-				return buff;
-			}
-			return buff.toString();
-		}).join('');
-	} else if (typeof buffs === 'string') {
-		return buffs;
-	} else if (Buffer.isBuffer(buffs)) {
-		return buffs.toString('utf8');
+	if (buffs.constructor.name === 'BufferList') {
+		return buffs.join();
 	}
 
 	return buffs.toString();


### PR DESCRIPTION
In node 6.3 `BufferList` was added to core `require('streams').Transform` which is what a dependency of `mock-express-response` depends on. The `_readableState.buffer` became a new object which wasn't be handled correctly.