### PR TITLE
updates cloudSearch for missing params

### DIFF
--- a/lib/services/catalog/controllers/catalog-search-controller.js
+++ b/lib/services/catalog/controllers/catalog-search-controller.js
@@ -10,8 +10,10 @@ class CatalogSearchController {
 	}
 
 	get(req, res, next) {
+		const theChannel = req.query.channel ? req.query.channel : req.identity.channel.id;
+
 		this.bus
-			.query({role: 'catalog', cmd: 'search'}, {query: req.query.q})
+			.query({role: 'catalog', cmd: 'search'}, {query: req.query.q, channel: theChannel, type: req.query.type})
 			.then(objects => {
 				res.body = objects;
 				next();

--- a/lib/services/catalog/controllers/catalog-search-controller.js
+++ b/lib/services/catalog/controllers/catalog-search-controller.js
@@ -10,10 +10,8 @@ class CatalogSearchController {
 	}
 
 	get(req, res, next) {
-		const theChannel = req.query.channel ? req.query.channel : req.identity.channel.id;
-
 		this.bus
-			.query({role: 'catalog', cmd: 'search'}, {query: req.query.q, channel: theChannel, type: req.query.type})
+			.query({role: 'catalog', cmd: 'search'}, {query: req.query.q, channel: req.identity.channel.id, type: req.query.type})
 			.then(objects => {
 				res.body = objects;
 				next();

--- a/lib/stores/cloudsearch/index.js
+++ b/lib/stores/cloudsearch/index.js
@@ -36,7 +36,7 @@ module.exports = function (bus, options) {
 			return Promise.reject(new Error('query() payload.channel String is required.'));
 		}
 
-		const typeFilter = [payload.type] || types;
+		const typeFilter = payload.type ? [payload.type] : types;
 
 		const facet = {
 			channel: {buckets: [payload.channel]},

--- a/lib/stores/cloudsearch/index.js
+++ b/lib/stores/cloudsearch/index.js
@@ -32,10 +32,6 @@ module.exports = function (bus, options) {
 			return Promise.reject(new Error('query() payload.query String is required.'));
 		}
 
-		if (!payload.channel || !_.isString(payload.channel)) {
-			return Promise.reject(new Error('query() payload.channel String is required.'));
-		}
-
 		const typeFilter = payload.type ? [payload.type] : types;
 
 		const facet = {


### PR DESCRIPTION
Disregard these changes if they conflict with some greater plan I am not aware of. Search results still not the same as Odd 2.
------
uses channel from jwt if not present in query
passes channel & type in payload
corrects facet  = [undefined] error on missing type