### PR TITLE
#126 removes a doubled baseUrl from an api response with a BASE_PREFIX

### DIFF
--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -125,8 +125,17 @@ module.exports = function (options) {
 				return format(object, baseUrl);
 			});
 
+			let link = `${baseUrl}`;
+			if (BASE_PREFIX && req.originalUrl.indexOf(BASE_PREFIX) === 0) {
+				// create a suffix that does not have the BASE_PREFIX in it
+				const suffix = req.originalUrl.substr(BASE_PREFIX.length, (req.originalUrl.length - BASE_PREFIX.length));
+				link += suffix;
+			} else {
+				link += `${req.originalUrl}`;
+			}
+
 			res.body.links = {
-				self: `${baseUrl}${req.originalUrl}`
+				self: link
 			};
 		} else {
 			if (_.isString(req.query.include)) {


### PR DESCRIPTION
This should solve a bug where the `links.self` on the main response from the api has a doubled `BASE_PREFIX`.