### PR TITLE
Tests for json api validation - with ?include

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "dynalite": "~1.0.0",
     "fakeredis": "~1.0.0",
     "jasmine": "~2.4.0",
+    "jsonschema": "^1.1.0",
     "mock-express-request": "~0.1.0",
     "mock-express-response": "~0.1.0",
     "nsp": "~2.4.0",

--- a/spec/helpers/json-api-schema.json
+++ b/spec/helpers/json-api-schema.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "JSON API Schema",
+  "description": "This is a schema for responses in the JSON API format. For more, see http://jsonapi.org",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/success"
+    },
+    {
+      "$ref": "#/definitions/failure"
+    },
+    {
+      "$ref": "#/definitions/info"
+    }
+  ],
+  
+  "definitions": {
+    "success": {
+      "type": "object",
+      "required": [
+        "data"
+      ],
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/data"
+        },
+        "included": {
+          "description": "To reduce the number of HTTP requests, servers **MAY** allow responses that include related resources along with the requested primary resources. Such responses are called \"compound documents\".",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/resource"
+          },
+          "uniqueItems": true
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        },
+        "links": {
+          "description": "Link members related to the primary data.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/links"
+            },
+            {
+              "$ref": "#/definitions/pagination"
+            }
+          ]
+        },
+        "jsonapi": {
+          "$ref": "#/definitions/jsonapi"
+        }
+      },
+      "additionalProperties": false
+    },
+    "failure": {
+      "type": "object",
+      "required": [
+        "errors"
+      ],
+      "properties": {
+        "errors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/error"
+          },
+          "uniqueItems": true
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        },
+        "jsonapi": {
+          "$ref": "#/definitions/jsonapi"
+        }
+      },
+      "additionalProperties": false
+    },
+    "info": {
+      "type": "object",
+      "required": [
+        "meta"
+      ],
+      "properties": {
+        "meta": {
+          "$ref": "#/definitions/meta"
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        },
+        "jsonapi": {
+          "$ref": "#/definitions/jsonapi"
+        }
+      },
+      "additionalProperties": false
+    },
+    
+    "meta": {
+      "description": "Non-standard meta-information that can not be represented as an attribute or relationship.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "data": {
+      "description": "The document's \"primary data\" is a representation of the resource or collection of resources targeted by a request.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/resource"
+        },
+        {
+          "description": "An array of resource objects, an array of resource identifier objects, or an empty array ([]), for requests that target resource collections.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/resource"
+          },
+          "uniqueItems": true
+        },
+        {
+          "description": "null if the request is one that might correspond to a single resource, but doesn't currently.",
+          "type": "null"
+        }
+      ]
+    },
+    "resource": {
+      "description": "\"Resource objects\" appear in a JSON API document to represent resources.",
+      "type": "object",
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "attributes": {
+          "$ref": "#/definitions/attributes"
+        },
+        "relationships": {
+          "$ref": "#/definitions/relationships"
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      },
+      "additionalProperties": false
+    },
+    
+    "links": {
+      "description": "A resource object **MAY** contain references to other resource objects (\"relationships\"). Relationships may be to-one or to-many. Relationships can be specified by including a member in a resource's links object.",
+      "type": "object",
+      "properties": {
+        "self": {
+          "description": "A `self` member, whose value is a URL for the relationship itself (a \"relationship URL\"). This URL allows the client to directly manipulate the relationship. For example, it would allow a client to remove an `author` from an `article` without deleting the people resource itself.",
+          "type": "string",
+          "format": "uri"
+        },
+        "related": {
+          "$ref": "#/definitions/link"
+        }
+      },
+      "additionalProperties": true
+    },
+    "link": {
+      "description": "A link **MUST** be represented as either: a string containing the link's URL or a link object.",
+      "oneOf": [
+        {
+          "description": "A string containing the link's URL.",
+          "type": "string",
+          "format": "uri"
+        },
+        {
+          "type": "object",
+          "required": [
+            "href"
+          ],
+          "properties": {
+            "href": {
+              "description": "A string containing the link's URL.",
+              "type": "string",
+              "format": "uri"
+            },
+            "meta": {
+              "$ref": "#/definitions/meta"
+            }
+          }
+        }
+      ]
+    },
+
+    "attributes": {
+      "description": "Members of the attributes object (\"attributes\") represent information about the resource object in which it's defined.",
+      "type": "object",
+      "patternProperties": {
+        "^(?!relationships$|links$)\\w[-\\w_]*$": {
+          "description": "Attributes may contain any valid JSON value."
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "relationships": {
+      "description": "Members of the relationships object (\"relationships\") represent references from the resource object in which it's defined to other resource objects.",
+      "type": "object",
+      "patternProperties": {
+        "^\\w[-\\w_]*$": {
+          "properties": {
+            "links": {
+              "$ref": "#/definitions/links"
+            },
+            "data": {
+              "description": "Member, whose value represents \"resource linkage\".",
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/relationshipToOne"
+                },
+                {
+                  "$ref": "#/definitions/relationshipToMany"
+                }
+              ]
+            },
+            "meta": {
+              "$ref": "#/definitions/meta"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "relationshipToOne": {
+      "description": "References to other resource objects in a to-one (\"relationship\"). Relationships can be specified by including a member in a resource's links object.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/empty"
+        },
+        {
+          "$ref": "#/definitions/linkage"
+        }
+      ]
+    },
+    "relationshipToMany": {
+      "description": "An array of objects each containing \"type\" and \"id\" members for to-many relationships.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/linkage"
+      },
+      "uniqueItems": true
+    },
+    "empty": {
+      "description": "Describes an empty to-one relationship.",
+      "type": "null"
+    },
+    "linkage": {
+      "description": "The \"type\" and \"id\" to non-empty members.",
+      "type": "object",
+      "required": [
+        "type",
+        "id"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      },
+      "additionalProperties": false
+    },
+    "pagination": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "description": "The first page of data",
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "null" }
+          ]
+        },
+        "last": {
+          "description": "The last page of data",
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "null" }
+          ]
+        },
+        "prev": {
+          "description": "The previous page of data",
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "null" }
+          ]
+        },
+        "next": {
+          "description": "The next page of data",
+          "oneOf": [
+            { "type": "string", "format": "uri" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    
+    "jsonapi": {
+      "description": "An object describing the server's implementation",
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string"
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      },
+      "additionalProperties": false
+    },
+    
+    "error": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A unique identifier for this particular occurrence of the problem.",
+          "type": "string"
+        },
+        "links": {
+          "$ref": "#/definitions/links"
+        },
+        "status": {
+          "description": "The HTTP status code applicable to this problem, expressed as a string value.",
+          "type": "string"
+        },
+        "code": {
+          "description": "An application-specific error code, expressed as a string value.",
+          "type": "string"
+        },
+        "title": {
+          "description": "A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization.",
+          "type": "string"
+        },
+        "detail": {
+          "description": "A human-readable explanation specific to this occurrence of the problem.",
+          "type": "string"
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "pointer": {
+              "description": "A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute].",
+              "type": "string"
+            },
+            "parameter": {
+              "description": "A string indicating which query parameter caused the error.",
+              "type": "string"
+            }
+          }
+        },
+        "meta": {
+          "$ref": "#/definitions/meta"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -1,0 +1,185 @@
+/* global describe, beforeAll, it, expect */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint-disable max-nested-callbacks */
+'use strict';
+
+const JSONSchemaValidator = require('jsonschema').Validator;
+const Validator = new JSONSchemaValidator();
+const fakeredis = require('fakeredis');
+const MockExpressResponse = require('mock-express-response');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const redisStore = require('../../lib/stores/redis/');
+const catalogService = require('../../lib/services/catalog');
+const identityService = require('../../lib/services/identity');
+const responseJsonApi = require('../../lib/middleware/response-json-api');
+const jsonApiSchema = require('../helpers/json-api-schema.json');
+const support = require('../support/');
+
+describe('Middleware Response JSON API', () => {
+	let bus;
+	const RES = new MockExpressResponse();
+	const RES2 = new MockExpressResponse();
+
+	const COLLECTION = Object.freeze({
+		id: '936ed036-45df-4190-afce-d71b860806d1',
+		type: 'collection',
+		channel: 'channel-id',
+		title: 'Title of the thing',
+		thing: 'This is a thing',
+		relationships: {
+			entities: {
+				data: [
+					{
+						id: '1111-0',
+						type: 'video'
+					},
+					{
+						id: '1111-1',
+						type: 'video'
+					},
+					{
+						id: '1111-2',
+						type: 'video'
+					}
+				]
+			}
+		},
+		meta: {
+			extra: 'info'
+		}
+	});
+
+	const REL_0 = Object.freeze({
+		id: '1111-0',
+		type: 'video',
+		title: 'Video 0',
+		description: 'Description 0',
+		url: 'http://www.nasa.gov/mp4/755425main_CoM_20130613b-320-jpl-0.mp4',
+		meta: {
+			source: 'itunes'
+		},
+		channel: 'channel-id'
+	});
+
+	const REL_1 = Object.freeze({
+		id: '1111-1',
+		type: 'video',
+		title: 'Video 1',
+		description: 'Description 1',
+		url: 'http://www.nasa.gov/mp4/755425main_CoM_20130613b-320-jpl-1.mp4',
+		meta: {
+			source: 'itunes'
+		},
+		channel: 'channel-id'
+	});
+
+	const REL_2 = Object.freeze({
+		id: '1111-2',
+		type: 'video',
+		title: 'Video 2',
+		description: 'Description 2',
+		url: 'http://www.nasa.gov/mp4/755425main_CoM_20130613b-320-jpl-2.mp3',
+		meta: {
+			source: 'itunes'
+		},
+		channel: 'channel-id'
+	});
+
+	const REQ = {
+		protocol: 'https',
+		hostname: 'example.com',
+		identity: {
+			channel: {id: 'channel-id'},
+			platform: {id: 'platform-id'}
+		},
+		socket: {
+			address: () => {
+				return {port: 3000};
+			}
+		},
+		query: ''
+	};
+
+	const REQ_INCLUDE = _.cloneDeep(REQ);
+
+	// Not required for this test, but needed when coming in from the api
+	REQ_INCLUDE.query = {include: 'entities,video'};
+
+	beforeAll(done => {
+		RES.body = COLLECTION;
+
+		bus = support.createBus();
+
+		this.service = null;
+
+		Promise.promisifyAll(fakeredis.RedisClient.prototype);
+		Promise.promisifyAll(fakeredis.Multi.prototype);
+
+		// Initialize a store
+		return redisStore(bus, {
+			types: ['collection', 'video'],
+			redis: fakeredis.createClient()
+		})
+		.then(store => {
+			this.store = store;
+		})
+		// Initialize an identity service
+		.then(() => {
+			return identityService(bus, {});
+		})
+		// Initialize the catalog service
+		.then(() => {
+			return catalogService(bus, {
+				updateFrequency: 1
+			});
+		})
+		.then(service => {
+			this.service = service;
+			return service;
+		})
+		.then(() => {
+			const cmd = 'set';
+			const role = 'store';
+
+			return Promise.all([
+				bus.sendCommand({role, cmd, type: 'video'}, REL_0),
+				bus.sendCommand({role, cmd, type: 'video'}, REL_1),
+				bus.sendCommand({role, cmd, type: 'video'}, REL_2),
+				bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION)
+			]);
+		})
+		.then(() => {
+			const args = {
+				channel: 'channel-id',
+				type: 'collection',
+				id: COLLECTION.id,
+				platform: 'platform-id',
+				include: ['entities']
+			};
+			return bus.query({role: 'store', cmd: 'get', type: 'collection'}, args)
+			.then(response => {
+				RES2.body = response;
+				return RES2;
+			});
+		})
+		.then(done)
+		.catch(done);
+	});
+
+	it('formats response body to valid jsonapi.org schema', () => {
+		responseJsonApi({bus})(REQ, RES, err => {
+			const v = Validator.validate(RES.body, jsonApiSchema);
+			expect(v.valid).toBe(true);
+			expect(err).toBe(undefined);
+		});
+	});
+	it('retrieves included entities as valid jsonapi.org schema', () => {
+		responseJsonApi({bus})(REQ_INCLUDE, RES2, err => {
+			const v = Validator.validate(RES2.body, jsonApiSchema);
+			expect(RES2.body.included.length).toBe(3);
+			expect(v.valid).toBeTruthy();
+			expect(err).toBe(undefined);
+		});
+	});
+});


### PR DESCRIPTION
This PR is for Issue #101.

It includes:
- A Schema validation for a statically typed, well-formed collection
- A Schema validation for a collection that has been stored, then retrieved, with `?includes=entities`
- Also a quick test to ensure that all of the related entities are included in the `body.included` array.

-Al