### PR TITLE
Pagination of relationships

### DIFF
--- a/lib/services/catalog/controllers/catalog-item-relationship-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-relationship-controller.js
@@ -14,7 +14,7 @@ class CatalogItemRelationshipController {
 
 	get(req, res, next) {
 		const relationshipKey = req.params.relationshipKey;
-		const include = req.query.include;
+		let include = req.query.include;
 
 		const args = {
 			channel: req.identity.channel,
@@ -25,15 +25,13 @@ class CatalogItemRelationshipController {
 			relationshipKey
 		};
 
-		if (include) {
-			args.include = req.query.include;
-		}
-
-		if ((req.query || {}).sort) {
-			if (!args.include) {
-				args.include = [relationshipKey];
-			} else if (args.include.indexOf(relationshipKey) < 0) {
-				args.include.push(relationshipKey);
+		if (include || (req.query || {}).sort) {
+			args.include = [relationshipKey];
+			if (include) {
+				// when ?include is present for this route only return the requested relationships
+				if (include.indexOf(relationshipKey) > -1) {
+					include = [relationshipKey];
+				}
 			}
 		}
 
@@ -66,7 +64,6 @@ class CatalogItemRelationshipController {
 						}
 
 						if (resource.included) {
-							// todo: handle multiple included types
 							resource.included = sorted;
 						}
 
@@ -82,7 +79,6 @@ class CatalogItemRelationshipController {
 						let offset = req.query.page.offset ? parseInt(req.query.page.offset, 10) : 0;
 						let limit = req.query.page.limit ? parseInt(req.query.page.limit, 10) : 10;
 
-						// todo - should non-Int page values throw a Boom error?
 						offset = isNaN(offset) ? 0 : offset;
 						limit = isNaN(limit) ? 10 : limit;
 

--- a/lib/services/catalog/controllers/catalog-item-relationship-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-relationship-controller.js
@@ -31,6 +31,8 @@ class CatalogItemRelationshipController {
 				// when ?include is present for this route only return the requested relationships
 				if (include.indexOf(relationshipKey) > -1) {
 					include = [relationshipKey];
+				} else {
+					include = false;
 				}
 			}
 		}

--- a/lib/services/catalog/controllers/catalog-item-relationship-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-relationship-controller.js
@@ -77,6 +77,31 @@ class CatalogItemRelationshipController {
 						});
 					}
 
+					// paging
+					if ((req.query || {}).page) {
+						let offset = req.query.page.offset ? parseInt(req.query.page.offset, 10) : 0;
+						let limit = req.query.page.limit ? parseInt(req.query.page.limit, 10) : 10;
+
+						// todo - should non-Int page values throw a Boom error?
+						offset = isNaN(offset) ? 0 : offset;
+						limit = isNaN(limit) ? 10 : limit;
+
+						const start = offset * limit;
+						let end = start + limit;
+
+						if (end > relationships.length) {
+							end = relationships.length;
+						}
+
+						// limit relationships
+						relationships.data = _.slice(relationships.data, start, end);
+
+						// limit includes
+						if (include) {
+							resource.included = _.slice(resource.included, start, end);
+						}
+					}
+
 					// add the included if needed
 					if (include) {
 						// todo: this needs to be tested with multiple included types

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "jsonwebtoken": "~7.1.0",
     "lodash": "^3.0.0",
     "node-uuid": "~1.4.0",
+    "object-property-natural-sort": "0.0.4",
     "oddcast": "~2.1.0",
     "redis-search": "~0.0.1"
   },
@@ -41,7 +42,6 @@
     "mock-express-request": "~0.1.0",
     "mock-express-response": "~0.1.0",
     "nsp": "~2.6.0",
-    "object-property-natural-sort": "0.0.4",
     "xo": "~0.16.0"
   },
   "xo": {

--- a/spec/services/catalog/controllers/catalog-item-relationship-controller-spec.js
+++ b/spec/services/catalog/controllers/catalog-item-relationship-controller-spec.js
@@ -289,4 +289,36 @@ describe('Catalog Item Relationship Controller', function () {
 			expect(data[9].id).toBe('1111-300');
 		});
 	});
+
+	it('with page query param, something happens', function () {
+		const req = {
+			params: {
+				id: COLLECTION_1.id,
+				relationshipKey: 'entities'
+			},
+			query: {
+				sort: 'title',
+				page: {
+					offset: '1',
+					limit: 3
+				},
+				include: ['entities']
+			},
+			identity: {channel: {id: CHANNEL.id},
+			platform: {id: PLATFORM.id},
+			user: {id: USER.id}}
+		};
+		const res = {
+			body: {},
+			status() {}
+		};
+
+		this.controller.relationship.get(req, res, () => {
+			const data = res.body.data;
+			expect(res.body.included.length).toBe(3);
+			expect(data.length).toBe(3);
+			expect(data[0].id).toBe('1111-10');
+			expect(res.body.included[0].title).toBe('10 Video');
+		});
+	});
 });


### PR DESCRIPTION
This PR should satisfy #64 - paging.
 - implements `?page[offset]={int}&page[limit]={int}` on relationships routes
 - limited what `?include=xxx` returns:
    - if the `:relationshipKey` was requested in the included param, we return that type only
    - if other types are requested other than the `:relationshipKey`, no included types are returned

-Al