### PR TITLE
JSON API Middleware bugfixes and paging feature

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 # Oddworks
 
 - [Resources](https://github.com/oddnetworks/oddworks/tree/master/docs/resources)
+- [Testing](https://github.com/oddnetworks/oddworks/tree/master/docs/testing)

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,246 @@
+Testing
+=======
+
+### ES6 Arrow Functions
+First __DON'T__ use arrow functions in `describe()`, `beforeAll()`, `beforeEach()`, `afterAll()`, `afterEach()`, or `it()` blocks. The reson is that the `this` object is set explicitly by Jasmine for those blocks so that `this` represents the same object throughout a test run, which can be [quite useful](http://jasmine.github.io/2.5/introduction.html#section-The_<code>this</code>_keyword). So, instead, the Jasmine test blocks should be setup the old school way.
+
+This requires `/* eslint-disable max-nested-callbacks */` to be set at the top of the file.
+
+Secondly, __DO__ use arrow functions in the callbacks within `beforeAll()` and `beforeEach()`. When you do that, the arrow function will reference the `this` object automatically set by Jasmine, allowing you to attach stuff to it.
+
+```js
+/* global describe, beforeAll, it, expect */
+/* eslint prefer-arrow-callback: 0 */
+'use strict';
+
+describe('My thing', function () {
+    let key = null;
+    let subject = null;
+
+    beforeAll(function (done) {
+        // Assume this.createKey() was defined in the global test setup
+        // beforeAll block for you to use here.
+        key = this.createKey();
+
+        return fetchSomething().then(something => {
+            subject = something;
+            subject.setKey(this.createKey());
+        }).then(done).catch(done.fail);
+    });
+
+    it('has correct key', function () {
+        expect(subject.key).toBe(key);
+    });
+});
+```
+
+### Test Setup
+Perform all asynchronous test setup tasks in a `beforeAll()` block within the `describe()` block where you intend to test it with `it()` blocks. This keeps all the asynchronous action in one place where it is easier to debug, and makes the rest of the test suite more readable.
+
+Set your test subjects inside the `describe()` block using `let` statements, and set them initially to `null`. Then, within your `beforeAll()` block assign the actual values.
+
+```js
+/* global describe, beforeAll, it, expect */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint-disable max-nested-callbacks */
+'use strict';
+
+const JSONSchemaValidator = require('jsonschema').Validator;
+const fakeredis = require('fakeredis');
+const MockExpressResponse = require('mock-express-response');
+const Promise = require('bluebird');
+const _ = require('lodash');
+const redisStore = require('../../lib/stores/redis/');
+const catalogService = require('../../lib/services/catalog');
+const identityService = require('../../lib/services/identity');
+const responseJsonApi = require('../../lib/middleware/response-json-api');
+const jsonApiSchema = require('../helpers/json-api-schema.json');
+
+const COLLECTION = require('../fixtures/collections/collection-0.json');
+const REL_0 = require('../fixtures/videos/video-0.json');
+const REL_1 = require('../fixtures/videos/video-1.json');
+const REL_2 = require('../fixtures/videos/video-2.json');
+
+const Validator = new JSONSchemaValidator();
+
+Promise.promisifyAll(fakeredis.RedisClient.prototype);
+Promise.promisifyAll(fakeredis.Multi.prototype);
+
+describe('Middleware Response JSON API', function () {
+    let bus = null;
+
+    const REQ = {
+        protocol: 'https',
+        hostname: 'example.com',
+        identity: {
+            channel: {id: 'channel-id'},
+            platform: {id: 'platform-id', platformType: 'APPLE_TV'}
+        },
+        socket: {
+            address: () => {
+                return {port: 3000};
+            }
+        },
+        query: ''
+    };
+
+    beforeAll(function (done) {
+        bus = this.createBus();
+
+        // Kicking off the chain with Promise.resolve(null) makes
+        // it easier to add more setup logic at the top of the chain
+        // via copy and paste. It also makes it easier to visually
+        // inspect the aync callback chain.
+        return Promise.resolve(null)
+            // Initialize a store
+            .then(() => {
+                return redisStore(bus, {
+                    types: ['collection', 'video'],
+                    redis: fakeredis.createClient()
+                });
+            })
+            // Initialize an identity service
+            .then(() => {
+                return identityService(bus, {});
+            })
+            // Initialize the catalog service
+            .then(() => {
+                return catalogService(bus, {
+                    updateFrequency: 1
+                });
+            })
+            // Seed content
+            .then(() => {
+                const cmd = 'set';
+                const role = 'store';
+
+                return Promise.all([
+                    bus.sendCommand({role, cmd, type: 'video'}, REL_0),
+                    bus.sendCommand({role, cmd, type: 'video'}, REL_1),
+                    bus.sendCommand({role, cmd, type: 'video'}, REL_2),
+                    bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION)
+                ]);
+            })
+            // Using a no-op at the end of the chain helps to ensure
+            // that no arguments will be pased to `done()`.
+            .then(_.noop)
+            .then(done)
+            // Using done.fail as our error handler will allow Jasmine error
+            // handling to kick in and make error conditions more readable.
+            .catch(done.fail);
+    });
+
+    describe('with single resource', function () {
+        let req = null;
+        let res = null;
+        let middleware = null;
+
+        beforeAll(function (done) {
+            req = _.cloneDeep(REQ);
+            res = new MockExpressResponse();
+            middleware = responseJsonApi({bus});
+
+            return Promise.resolve(null)
+                // Load seed data (without using include)
+                .then(() => {
+                    const role = 'store';
+                    const cmd = 'get';
+                    const type = 'collection';
+
+                    const args = {
+                        channel: 'channel-id',
+                        type,
+                        id: COLLECTION.id,
+                        platform: 'platform-id'
+                    };
+
+                    return bus.query({role, cmd, type}, args).then(result => {
+                        res.body = result;
+                    });
+                })
+                .then(() => {
+                    return middleware(req, res, err => {
+                        if (err) {
+                            return done.fail(err);
+                        }
+                        done();
+                    });
+                })
+                .then(_.noop)
+                .then(done)
+                .catch(done.fail);
+        });
+
+        it('formats response body to valid jsonapi.org schema', function () {
+            const v = Validator.validate(res.body, jsonApiSchema);
+            expect(v.valid).toBe(true);
+        });
+
+        it('has no includes array', function () {
+            expect(res.body.includes).not.toBeDefined();
+        });
+
+        it('adds a meta block', function () {
+            expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'APPLE_TV'});
+        });
+    });
+
+    describe('with included resources', function () {
+        let req = null;
+        let res = null;
+        let middleware = null;
+
+        beforeAll(function (done) {
+            req = _.cloneDeep(REQ);
+            req.query = {include: 'entities,video'};
+            res = new MockExpressResponse();
+            middleware = responseJsonApi({bus});
+
+            return Promise.resolve(null)
+                // Load seed data (without using include)
+                .then(() => {
+                    const role = 'store';
+                    const cmd = 'get';
+                    const type = 'collection';
+
+                    const args = {
+                        channel: 'channel-id',
+                        type,
+                        id: COLLECTION.id,
+                        platform: 'platform-id',
+                        include: ['entities']
+                    };
+
+                    return bus.query({role, cmd, type}, args).then(result => {
+                        res.body = result;
+                    });
+                })
+                .then(() => {
+                    return middleware(req, res, err => {
+                        if (err) {
+                            return done.fail(err);
+                        }
+                        done();
+                    });
+                })
+                .then(_.noop)
+                .then(done)
+                .catch(done.fail);
+        });
+
+        it('formats response body to valid jsonapi.org schema', function () {
+            const v = Validator.validate(res.body, jsonApiSchema);
+            expect(v.valid).toBe(true);
+        });
+
+        it('has an includes array', function () {
+            expect(Array.isArray(res.body.included)).toBe(true);
+            expect(res.body.included.length).toBe(3);
+        });
+
+        it('adds a meta block', function () {
+            expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'APPLE_TV'});
+        });
+    });
+});
+```

--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -71,12 +71,15 @@ module.exports = function (options) {
 			// Only include relationships actually referenced.
 			// Remove relationship references that were not found.
 			if (Array.isArray(rel)) {
-				rel.slice().forEach((item, i) => {
+				rel.slice().forEach(item => {
 					const res = inIncluded(item, key);
 					if (res) {
 						finalIncluded.push(res);
 					} else {
-						rel.splice(i, 1);
+						const i = rel.indexOf(item);
+						if (i >= 0) {
+							rel.splice(i, 1);
+						}
 					}
 				});
 			} else {

--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const url = require('url');
+const querystring = require('querystring');
 const _ = require('lodash');
 const Boom = require('boom');
 
@@ -27,8 +29,11 @@ module.exports = function (options) {
 		if (data.id && data.type) {
 			resource.id = data.id;
 			resource.type = data.type;
+
 			resource.attributes = _.omit(data, JSON_API_KEYS);
-			resource.relationships = data.relationships || {};
+
+			resource.relationships = data.relationships ? _.cloneDeep(data.relationships) : {};
+
 			if (resource.type === 'config') {
 				resource.links = {
 					self: `${baseUrl}/config`
@@ -38,7 +43,8 @@ module.exports = function (options) {
 					self: `${baseUrl}/${resource.type}s/${resource.id}`
 				};
 			}
-			resource.meta = data.meta || {};
+
+			resource.meta = data.meta ? _.cloneDeep(data.meta) : {};
 		}
 
 		return resource;
@@ -125,23 +131,42 @@ module.exports = function (options) {
 			baseUrl = `${baseUrl}${BASE_PREFIX}`;
 		}
 
-		const data = _.cloneDeep(res.body);
-		res.body = {};
+		let data;
 
-		if (_.isArray(data)) {
+		if (_.isArray(res.body)) {
+			data = res.body.slice();
+			const linksQueries = res.body.linksQueries;
+			res.body = {};
+
 			res.body.data = data.map(object => {
 				delete object.included;
 				return format(object, baseUrl);
 			});
 
+			const baseSelfLink = `${baseUrl}/${data[0].type}s`;
+			const query = url.parse(req.url).query;
+			const selfLink = query ? `${baseSelfLink}?${query}` : baseSelfLink;
+
 			res.body.links = {
-				self: `${baseUrl}${req.originalUrl}`
+				self: selfLink
 			};
+
+			if (linksQueries) {
+				Object.keys(linksQueries).forEach(key => {
+					const qs = querystring.stringify(linksQueries[key]);
+					res.body.links[key] = `${baseSelfLink}?${qs}`;
+				});
+			}
 		} else {
+			data = _.cloneDeep(res.body);
+			res.body = {};
+
 			if (_.isString(req.query.include)) {
 				res.body.included = composeIncluded(req.query.include, data, baseUrl);
 			}
+
 			delete data.included;
+
 			res.body.data = format(data, baseUrl);
 			res.body.links = res.body.data.links;
 		}

--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -6,9 +6,14 @@ const Boom = require('boom');
 const JSON_API_KEYS = ['id', 'type', 'relationships', 'meta', 'links'];
 
 // options.bus - Object *required*
+// options.baseUrlPrefix - String ex: "/v2".
+// options.excludePortFromLinks - Boolean (default == false) If true, don't
+//   include the port number in links.
 module.exports = function (options) {
 	options = options || {};
+
 	const BASE_PREFIX = options.baseUrlPrefix;
+	const EXCLUDE_PORT_FROM_LINKS = Boolean(options.excludePortFromLinks);
 
 	const bus = options.bus;
 
@@ -109,9 +114,10 @@ module.exports = function (options) {
 			defaultPort = true;
 		}
 
-		if (!defaultPort && process.env.NODE_ENV && process.env.NODE_ENV.toUpperCase() !== 'PRODUCTION') {
+		if (!defaultPort && !EXCLUDE_PORT_FROM_LINKS) {
 			baseUrl = `${baseUrl}:${port}`;
 		}
+
 		if (BASE_PREFIX) {
 			baseUrl = `${baseUrl}${BASE_PREFIX}`;
 		}
@@ -125,17 +131,8 @@ module.exports = function (options) {
 				return format(object, baseUrl);
 			});
 
-			let link = `${baseUrl}`;
-			if (BASE_PREFIX && req.originalUrl.indexOf(BASE_PREFIX) === 0) {
-				// create a suffix that does not have the BASE_PREFIX in it
-				const suffix = req.originalUrl.substr(BASE_PREFIX.length, (req.originalUrl.length - BASE_PREFIX.length));
-				link += suffix;
-			} else {
-				link += `${req.originalUrl}`;
-			}
-
 			res.body.links = {
-				self: link
+				self: `${baseUrl}${req.originalUrl}`
 			};
 		} else {
 			if (_.isString(req.query.include)) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/oddworks.js",
   "scripts": {
     "setup": "npm link",
-    "test": "NODE_ENV=test npm run lint && npm run sec && jasmine",
+    "test": "NODE_ENV=test npm run lint && NODE_ENV=test npm run sec && NODE_ENV=test jasmine",
     "lint": "xo",
     "sec": "./node_modules/.bin/nsp check -o summary --warn-only"
   },

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -13,7 +13,6 @@ const catalogService = require('../../lib/services/catalog');
 const identityService = require('../../lib/services/identity');
 const responseJsonApi = require('../../lib/middleware/response-json-api');
 const jsonApiSchema = require('../helpers/json-api-schema.json');
-const support = require('../support/');
 
 const COLLECTION = require('../fixtures/collections/collection-0.json');
 const REL_0 = require('../fixtures/videos/video-0.json');
@@ -22,17 +21,18 @@ const REL_2 = require('../fixtures/videos/video-2.json');
 
 const Validator = new JSONSchemaValidator();
 
-describe('Middleware Response JSON API', () => {
-	let bus;
-	const RES = new MockExpressResponse();
-	const RES2 = new MockExpressResponse();
+Promise.promisifyAll(fakeredis.RedisClient.prototype);
+Promise.promisifyAll(fakeredis.Multi.prototype);
+
+describe('Middleware Response JSON API', function () {
+	let bus = null;
 
 	const REQ = {
 		protocol: 'https',
 		hostname: 'example.com',
 		identity: {
 			channel: {id: 'channel-id'},
-			platform: {id: 'platform-id'}
+			platform: {id: 'platform-id', platformType: 'APPLE_TV'}
 		},
 		socket: {
 			address: () => {
@@ -42,85 +42,154 @@ describe('Middleware Response JSON API', () => {
 		query: ''
 	};
 
-	const REQ_INCLUDE = _.cloneDeep(REQ);
+	beforeAll(function (done) {
+		bus = this.createBus();
 
-	// Not required for this test, but needed when coming in from the api
-	REQ_INCLUDE.query = {include: 'entities,video'};
+		return Promise.resolve(null)
+			// Initialize a store
+			.then(() => {
+				return redisStore(bus, {
+					types: ['collection', 'video'],
+					redis: fakeredis.createClient()
+				});
+			})
+			// Initialize an identity service
+			.then(() => {
+				return identityService(bus, {});
+			})
+			// Initialize the catalog service
+			.then(() => {
+				return catalogService(bus, {
+					updateFrequency: 1
+				});
+			})
+			// Seed content
+			.then(() => {
+				const cmd = 'set';
+				const role = 'store';
 
-	beforeAll(done => {
-		RES.body = COLLECTION;
-
-		bus = support.createBus();
-
-		this.service = null;
-
-		Promise.promisifyAll(fakeredis.RedisClient.prototype);
-		Promise.promisifyAll(fakeredis.Multi.prototype);
-
-		// Initialize a store
-		return redisStore(bus, {
-			types: ['collection', 'video'],
-			redis: fakeredis.createClient()
-		})
-		.then(store => {
-			this.store = store;
-		})
-		// Initialize an identity service
-		.then(() => {
-			return identityService(bus, {});
-		})
-		// Initialize the catalog service
-		.then(() => {
-			return catalogService(bus, {
-				updateFrequency: 1
-			});
-		})
-		.then(service => {
-			this.service = service;
-			return service;
-		})
-		.then(() => {
-			const cmd = 'set';
-			const role = 'store';
-
-			return Promise.all([
-				bus.sendCommand({role, cmd, type: 'video'}, REL_0),
-				bus.sendCommand({role, cmd, type: 'video'}, REL_1),
-				bus.sendCommand({role, cmd, type: 'video'}, REL_2),
-				bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION)
-			]);
-		})
-		.then(() => {
-			const args = {
-				channel: 'channel-id',
-				type: 'collection',
-				id: COLLECTION.id,
-				platform: 'platform-id',
-				include: ['entities']
-			};
-			return bus.query({role: 'store', cmd: 'get', type: 'collection'}, args)
-			.then(response => {
-				RES2.body = response;
-				return RES2;
-			});
-		})
-		.then(done)
-		.catch(done);
+				return Promise.all([
+					bus.sendCommand({role, cmd, type: 'video'}, REL_0),
+					bus.sendCommand({role, cmd, type: 'video'}, REL_1),
+					bus.sendCommand({role, cmd, type: 'video'}, REL_2),
+					bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION)
+				]);
+			})
+			.then(_.noop)
+			.then(done)
+			.catch(done.fail);
 	});
 
-	it('formats response body to valid jsonapi.org schema', () => {
-		responseJsonApi({bus})(REQ, RES, err => {
-			const v = Validator.validate(RES.body, jsonApiSchema);
+	describe('with single resource', function () {
+		let req = null;
+		let res = null;
+		let middleware = null;
+
+		beforeAll(function (done) {
+			req = _.cloneDeep(REQ);
+			res = new MockExpressResponse();
+			middleware = responseJsonApi({bus});
+
+			return Promise.resolve(null)
+				// Load seed data (without using include)
+				.then(() => {
+					const role = 'store';
+					const cmd = 'get';
+					const type = 'collection';
+
+					const args = {
+						channel: 'channel-id',
+						type,
+						id: COLLECTION.id,
+						platform: 'platform-id'
+					};
+
+					return bus.query({role, cmd, type}, args).then(result => {
+						res.body = result;
+					});
+				})
+				.then(() => {
+					return middleware(req, res, err => {
+						if (err) {
+							return done.fail(err);
+						}
+						done();
+					});
+				})
+				.then(_.noop)
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('formats response body to valid jsonapi.org schema', function () {
+			const v = Validator.validate(res.body, jsonApiSchema);
 			expect(v.valid).toBe(true);
-			expect(err).toBe(undefined);
+		});
+
+		it('has no includes array', function () {
+			expect(res.body.includes).not.toBeDefined();
+		});
+
+		it('adds a meta block', function () {
+			expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'APPLE_TV'});
 		});
 	});
-	it('retrieves included entities as valid jsonapi.org schema', () => {
-		responseJsonApi({bus})(REQ_INCLUDE, RES2, err => {
-			const v = Validator.validate(RES2.body, jsonApiSchema);
-			expect(RES2.body.included.length).toBe(3);
-			expect(v.valid).toBeTruthy();
-			expect(err).toBe(undefined);
+
+	describe('with included resources', function () {
+		let req = null;
+		let res = null;
+		let middleware = null;
+
+		beforeAll(function (done) {
+			req = _.cloneDeep(REQ);
+			req.query = {include: 'entities,video'};
+			res = new MockExpressResponse();
+			middleware = responseJsonApi({bus});
+
+			return Promise.resolve(null)
+				// Load seed data (without using include)
+				.then(() => {
+					const role = 'store';
+					const cmd = 'get';
+					const type = 'collection';
+
+					const args = {
+						channel: 'channel-id',
+						type,
+						id: COLLECTION.id,
+						platform: 'platform-id',
+						include: ['entities']
+					};
+
+					return bus.query({role, cmd, type}, args).then(result => {
+						res.body = result;
+					});
+				})
+				.then(() => {
+					return middleware(req, res, err => {
+						if (err) {
+							return done.fail(err);
+						}
+						done();
+					});
+				})
+				.then(_.noop)
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('formats response body to valid jsonapi.org schema', function () {
+			const v = Validator.validate(res.body, jsonApiSchema);
+			expect(v.valid).toBe(true);
+		});
+
+		it('has an includes array', function () {
+			expect(Array.isArray(res.body.included)).toBe(true);
+			expect(res.body.included.length).toBe(3);
+		});
+
+		it('adds a meta block', function () {
+			expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'APPLE_TV'});
 		});
 	});
 });

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -288,6 +288,78 @@ describe('Middleware Response JSON API', function () {
 		});
 	});
 
+	// xdescribe('with listing data', function () {
+	// 	let req = null;
+	// 	let res = null;
+	// 	let middleware = null;
+
+	// 	beforeAll(function (done) {
+	// 		req = _.cloneDeep(REQ);
+	// 		req.query = {include: 'entities,video'};
+	// 		res = new MockExpressResponse();
+	// 		middleware = responseJsonApi({bus});
+	// 		done();
+	// 	});
+	// });
+
+	describe('with baseUrlPrefix', function () {
+		let req = null;
+		let res = null;
+		let middleware = null;
+
+		beforeAll(function (done) {
+			req = _.cloneDeep(REQ);
+			req.query = {include: 'entities,video'};
+			res = new MockExpressResponse();
+			middleware = responseJsonApi({
+				bus,
+				baseUrlPrefix: '/v2'
+			});
+
+			return Promise.resolve(null)
+				// Load seed data
+				.then(() => {
+					const role = 'store';
+					const cmd = 'get';
+					const type = 'collection';
+
+					const args = {
+						channel: 'channel-id',
+						type,
+						id: COLLECTION.id,
+						platform: 'platform-id',
+						include: ['entities']
+					};
+
+					return bus.query({role, cmd, type}, args).then(result => {
+						res.body = result;
+					});
+				})
+				.then(() => {
+					return middleware(req, res, err => {
+						if (err) {
+							return done.fail(err);
+						}
+						done();
+					});
+				})
+				.then(_.noop)
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('includes base prefix in included resources links', function () {
+			const included = res.body.included || [];
+			expect(included[0].links.self).toBe('https://example.com:3000/v2/videos/1111-0');
+			expect(included[1].links.self).toBe('https://example.com:3000/v2/videos/1111-1');
+			expect(included[2].links.self).toBe('https://example.com:3000/v2/videos/1111-2');
+		});
+
+		it('includes base prefix in self link', function () {
+			expect(res.body.links.self).toBe('https://example.com:3000/v2/collections/collection-0');
+		});
+	});
+
 	describe('with excludePortFromLinks == true', function () {
 		let req = null;
 		let res = null;

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -130,6 +130,10 @@ describe('Middleware Response JSON API', function () {
 			expect(res.body.includes).not.toBeDefined();
 		});
 
+		it('has a self link', function () {
+			expect(res.body.links.self).toBe('https://example.com:3000/collections/collection-0');
+		});
+
 		it('adds a meta block', function () {
 			expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'APPLE_TV'});
 		});
@@ -186,6 +190,17 @@ describe('Middleware Response JSON API', function () {
 		it('has an includes array', function () {
 			expect(Array.isArray(res.body.included)).toBe(true);
 			expect(res.body.included.length).toBe(3);
+		});
+
+		it('has included resources with self links', function () {
+			const included = res.body.included || [];
+			expect(included[0].links.self).toBe('https://example.com:3000/videos/1111-0');
+			expect(included[1].links.self).toBe('https://example.com:3000/videos/1111-1');
+			expect(included[2].links.self).toBe('https://example.com:3000/videos/1111-2');
+		});
+
+		it('has a self link', function () {
+			expect(res.body.links.self).toBe('https://example.com:3000/collections/collection-0');
 		});
 
 		it('adds a meta block', function () {


### PR DESCRIPTION
- Improves the tests for JSON API response middleware
- Document testing best practices
- Fixes bug #160 in dynamic broken relationships cleanup on response
- Adds an excludePortFromLinks option
- Adds paging (next, previous) links capability to json api response middleware