### PR TITLE
Issue 177

### DIFF
--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -12,8 +12,14 @@ class CatalogItemController {
 	}
 
 	get(req, res, next) {
+		let channelId = (req.identity.channel || {}).id;
+
+		// only allow channel from the queryString from an admin
+		if (!channelId && (req.identity.audience || []).includes('admin')) {
+			channelId = req.query.channel || '';
+		}
+
 		const args = {
-			channel: req.identity.channel,
 			type: this.type,
 			id: req.params.id,
 			platform: req.identity.platform,
@@ -24,8 +30,27 @@ class CatalogItemController {
 			args.include = req.query.include.split(',');
 		}
 
-		this.bus
-			.query({role: 'catalog', cmd: 'fetchItem'}, args)
+		let promise;
+		if (req.identity.channel) {
+			promise = Promise.resolve(req.identity.channel);
+		} else if (channelId) {
+			promise = this.bus.query(
+				{role: 'store', cmd: 'get', type: 'channel'},
+				{type: 'channel', id: channelId}
+			);
+		} else {
+			return next(Boom.badData('"channel" is required'));
+		}
+
+		return promise
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+
+				args.channel = channel;
+				return this.bus.query({role: 'catalog', cmd: 'fetchItem'}, args);
+			})
 			.then(resource => {
 				res.body = resource;
 				next();

--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -39,7 +39,7 @@ class CatalogItemController {
 		let channelId = (req.identity.channel || {}).id;
 
 		// only allow channel from the payload from an admin
-		if (!channelId && req.identity.audience.indexOf('admin') > -1) {
+		if (!channelId && (req.identity.audience || []).includes('admin')) {
 			channelId = (payload.channel || {}).id;
 		}
 

--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -36,28 +36,40 @@ class CatalogItemController {
 	patch(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		const channel = payload.channel || (req.identity.channel || {}).id;
+		const channelId = payload.channel || (req.identity.channel || {}).id;
 
-		if (type !== 'channel' && !channel) {
+		let promise;
+		if (req.identity.channel) {
+			promise = Promise.resolve(req.identity.channel);
+		} else if (channelId) {
+			promise = this.bus.query(
+				{role: 'store', cmd: 'get', type: 'channel'},
+				{type: 'channel', id: channelId}
+			);
+		} else {
 			return next(Boom.badData('"channel" is required'));
 		}
 
 		const args = {
-			channel: req.identity.channel,
 			type: this.type,
 			id: req.params.id,
 			platform: req.identity.platform,
 			user: req.identity.user
 		};
 
-		this.bus
-			.query({role: 'catalog', cmd: 'fetchItem'}, args)
+		return promise
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+				args.channel = channel;
+				return this.bus.query({role: 'catalog', cmd: 'fetchItem'}, args);
+			})
 			.then(resource => {
 				resource = _.merge({}, resource, payload);
-				resource.channel = channel;
+				resource.channel = channelId;
 				resource.type = type;
 				resource.id = args.id;
-
 				return this.bus.sendCommand({role: 'catalog', cmd: 'setItem'}, resource);
 			})
 			.then(resource => {

--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -36,7 +36,12 @@ class CatalogItemController {
 	patch(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		const channelId = payload.channel || (req.identity.channel || {}).id;
+		let channelId = (req.identity.channel || {}).id;
+
+		// only allow channel from the payload from an admin
+		if (!channelId && req.identity.audience.indexOf('admin') > -1) {
+			channelId = (payload.channel || {}).id;
+		}
 
 		let promise;
 		if (req.identity.channel) {

--- a/lib/services/catalog/controllers/catalog-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-list-controller.js
@@ -37,7 +37,12 @@ class CatalogListController {
 	post(req, res, next) {
 		const payload = _.cloneDeep(req.body);
 		const type = this.type;
-		const channelId = payload.channel || (req.identity.channel || {}).id;
+		let channelId = (req.identity.channel || {}).id;
+
+		// only allow channel from the payload from an admin
+		if (!channelId && (req.identity.audience || []).includes('admin')) {
+			channelId = (payload.channel || {}).id;
+		}
 
 		let promise;
 		if (req.identity.channel) {

--- a/lib/services/catalog/controllers/catalog-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-list-controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Boom = require('boom');
 
 const controller = require('../../../controllers/controller');
 
@@ -35,15 +36,36 @@ class CatalogListController {
 
 	post(req, res, next) {
 		const payload = _.cloneDeep(req.body);
-		payload.channel = req.identity.channel.id;
-		payload.type = this.type;
+		const type = this.type;
+		const channelId = payload.channel || (req.identity.channel || {}).id;
 
-		this.bus
-			.sendCommand({role: 'catalog', cmd: 'setItem'}, payload)
+		let promise;
+		if (req.identity.channel) {
+			promise = Promise.resolve(req.identity.channel);
+		} else if (channelId) {
+			promise = this.bus.query(
+				{role: 'store', cmd: 'get', type: 'channel'},
+				{type: 'channel', id: channelId}
+			);
+		} else {
+			return next(Boom.badData('"channel" is required'));
+		}
+
+		return promise
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+
+				payload.channel = channel.id;
+				payload.type = type;
+
+				return this.bus.sendCommand({role: 'catalog', cmd: 'setItem'}, payload);
+			})
 			.then(resource => {
 				res.body = resource;
 				res.status(201);
-				next();
+				return next();
 			})
 			.catch(next);
 	}

--- a/lib/services/catalog/controllers/catalog-spec-controller.js
+++ b/lib/services/catalog/controllers/catalog-spec-controller.js
@@ -75,6 +75,10 @@ class CatalogItemSpecController {
 
 		return promise
 			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+
 				const args = {channel, type, id};
 
 				return this.bus.query({role: 'catalog', cmd: 'fetchItemSpec'}, args);

--- a/lib/services/catalog/controllers/catalog-spec-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-spec-list-controller.js
@@ -51,7 +51,12 @@ class CatalogItemSpecListController {
 	post(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		const channelId = payload.channel || (req.identity.channel || {}).id;
+		let channelId = (req.identity.channel || {}).id;
+
+		// only allow channel from the payload from an admin
+		if (!channelId && (req.identity.audience || []).includes('admin')) {
+			channelId = (payload.channel || {}).id;
+		}
 
 		let promise;
 		if (req.identity.channel) {

--- a/lib/services/identity/controllers/identity-item-controller.js
+++ b/lib/services/identity/controllers/identity-item-controller.js
@@ -45,7 +45,12 @@ class IdentityItemController {
 	patch(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		const channelId = payload.channel || (req.identity.channel || {}).id;
+		let channelId = (req.identity.channel || {}).id;
+
+		// only allow channel from the payload from an admin
+		if (!channelId && (req.identity.audience || []).includes('admin')) {
+			channelId = (payload.channel || {}).id;
+		}
 
 		if (type !== 'channel' && !channelId) {
 			return next(Boom.badData('"channel" is required'));

--- a/lib/services/identity/controllers/identity-item-controller.js
+++ b/lib/services/identity/controllers/identity-item-controller.js
@@ -45,9 +45,9 @@ class IdentityItemController {
 	patch(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		const channel = payload.channel || (req.identity.channel || {}).id;
+		const channelId = payload.channel || (req.identity.channel || {}).id;
 
-		if (type !== 'channel' && !channel) {
+		if (type !== 'channel' && !channelId) {
 			return next(Boom.badData('"channel" is required'));
 		}
 
@@ -56,12 +56,29 @@ class IdentityItemController {
 			id: req.params.id
 		};
 
-		if (type !== 'channel') {
-			args.channel = channel;
+		let promise;
+		if (req.identity.channel) {
+			promise = Promise.resolve(req.identity.channel);
+		} else if (channelId) {
+			promise = this.bus.query(
+				{role: 'store', cmd: 'get', type: 'channel'},
+				{type: 'channel', id: channelId}
+			);
+		} else {
+			return next(Boom.badData('"channel" is required'));
 		}
 
-		return this.bus
-			.query({role: 'store', cmd: 'get', type}, args)
+		return promise
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+
+				if (type !== 'channel') {
+					args.channel = channel.id;
+				}
+				return this.bus.query({role: 'store', cmd: 'get', type}, args);
+			})
 			.then(resource => {
 				if (!resource) {
 					return next(Boom.notFound(`cannot find ${type} ${args.id}`));

--- a/lib/services/identity/controllers/identity-list-controller.js
+++ b/lib/services/identity/controllers/identity-list-controller.js
@@ -33,15 +33,42 @@ class IdentityListController {
 	post(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
+		const channelId = payload.channel || (req.identity.channel || {}).id;
+		payload.type = type;
 
-		if (type !== 'channel' && !payload.channel) {
+		if (type === 'channel') {
+			return this.bus
+				.sendCommand({role: 'store', cmd: 'set', type}, payload)
+				.then(resource => {
+					res.body = resource;
+					res.status(201);
+					return next();
+				})
+				.catch(next);
+		}
+
+		let promise;
+		if (req.identity.channel) {
+			promise = Promise.resolve(req.identity.channel);
+		} else if (channelId) {
+			promise = this.bus.query(
+				{role: 'store', cmd: 'get', type: 'channel'},
+				{type: 'channel', id: channelId}
+			);
+		} else {
 			return next(Boom.badData('"channel" is required'));
 		}
 
-		payload.type = type;
+		return promise
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
 
-		return this.bus
-			.sendCommand({role: 'store', cmd: 'set', type}, payload)
+				payload.channel = channel.id;
+
+				return this.bus.sendCommand({cmd: 'set', type}, payload);
+			})
 			.then(resource => {
 				res.body = resource;
 				res.status(201);

--- a/lib/services/identity/controllers/identity-list-controller.js
+++ b/lib/services/identity/controllers/identity-list-controller.js
@@ -33,8 +33,13 @@ class IdentityListController {
 	post(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		const channelId = payload.channel || (req.identity.channel || {}).id;
 		payload.type = type;
+		let channelId = (req.identity.channel || {}).id;
+
+		// only allow channel from the payload from an admin
+		if (!channelId && (req.identity.audience || []).includes('admin')) {
+			channelId = (payload.channel || {}).id;
+		}
 
 		if (type === 'channel') {
 			return this.bus

--- a/spec/services/catalog/controllers/catalog-item-controller-spec.js
+++ b/spec/services/catalog/controllers/catalog-item-controller-spec.js
@@ -90,7 +90,7 @@ describe('Catalog Service Controller', function () {
 		.catch(done.fail);
 	});
 
-	it('returns a collection object', function () {
+	it('returns a collection object', function (done) {
 		const req = {
 			params: {id: 'collection-13'},
 			query: {},
@@ -107,10 +107,11 @@ describe('Catalog Service Controller', function () {
 			expect(res.body.type).toBe('collection');
 			expect(res.body.title).toBe('Collection 13');
 			expect(res.body.channel).toBe('odd-networks');
+			done();
 		});
 	});
 
-	it('returns a video object', function () {
+	it('returns a video object', function (done) {
 		const req = {
 			params: {id: 'video-13'},
 			query: {},
@@ -127,10 +128,11 @@ describe('Catalog Service Controller', function () {
 			expect(res.body.type).toBe('video');
 			expect(res.body.title).toBe('Video 13');
 			expect(res.body.channel).toBe('odd-networks');
+			done();
 		});
 	});
 
-	it('updates a collection object', function () {
+	it('updates a collection object', function (done) {
 		const req = {
 			params: {id: 'collection-13'},
 			query: {},
@@ -151,10 +153,11 @@ describe('Catalog Service Controller', function () {
 			expect(res.body.type).toBe('collection');
 			expect(res.body.title).toBe('Odd');
 			expect(res.body.description).toBe('How odd are you?');
+			done();
 		});
 	});
 
-	it('updates a video object', function () {
+	it('updates a video object', function (done) {
 		const req = {
 			params: {id: 'video-13'},
 			query: {},
@@ -176,10 +179,11 @@ describe('Catalog Service Controller', function () {
 			expect(res.body.channel).toBe('odd-networks');
 			expect(res.body.title).toBe('Video 13');
 			expect(res.body.actor).toBe('Batman');
+			done();
 		});
 	});
 
-	it('deletes a collection object', function () {
+	it('deletes a collection object', function (done) {
 		const req = {
 			params: {id: 'collection-13'},
 			query: {},
@@ -197,10 +201,11 @@ describe('Catalog Service Controller', function () {
 			expect(res.body.type).toBeUndefined();
 			expect(res.body.title).toBeUndefined();
 			expect(res.body.description).toBeUndefined();
+			done();
 		});
 	});
 
-	it('deletes a video object', function () {
+	it('deletes a video object', function (done) {
 		const req = {
 			params: {id: 'video-13'},
 			query: {},
@@ -219,6 +224,7 @@ describe('Catalog Service Controller', function () {
 			expect(res.body.channel).toBeUndefined();
 			expect(res.body.title).toBeUndefined();
 			expect(res.body.category).toBeUndefined();
+			done();
 		});
 	});
 });

--- a/spec/services/catalog/controllers/catalog-item-controller-spec.js
+++ b/spec/services/catalog/controllers/catalog-item-controller-spec.js
@@ -94,7 +94,12 @@ describe('Catalog Service Controller', function () {
 		const req = {
 			params: {id: 'collection-13'},
 			query: {},
-			identity: {channel: {id: 'odd-networks'}, platform: {id: 'apple-ios'}, user: {id: 'user-id'}}
+			identity: {
+				channel: {id: 'odd-networks'},
+				platform: {id: 'apple-ios'},
+				user: {id: 'user-id'},
+				audience: 'admin'
+			}
 		};
 		const res = {
 			body: {},
@@ -136,7 +141,12 @@ describe('Catalog Service Controller', function () {
 		const req = {
 			params: {id: 'collection-13'},
 			query: {},
-			identity: {channel: {id: 'odd-networks'}, platform: {id: 'apple-ios'}, user: {id: 'user-id'}},
+			identity: {
+				channel: {id: 'odd-networks'},
+				platform: {id: 'apple-ios'},
+				user: {id: 'user-id'},
+				audience: 'admin'
+			},
 			body: {
 				title: 'Odd',
 				description: 'How odd are you?'
@@ -161,7 +171,12 @@ describe('Catalog Service Controller', function () {
 		const req = {
 			params: {id: 'video-13'},
 			query: {},
-			identity: {channel: {id: 'odd-networks'}, platform: {id: 'apple-ios'}, user: {id: 'user-id'}},
+			identity: {
+				channel: {id: 'odd-networks'},
+				platform: {id: 'apple-ios'},
+				user: {id: 'user-id'},
+				audience: 'admin'
+			},
 			body: {
 				channel: 'odd-networks',
 				actor: 'Batman'

--- a/spec/services/identity/controllers/identity-item-controller-spec.js
+++ b/spec/services/identity/controllers/identity-item-controller-spec.js
@@ -65,7 +65,7 @@ describe('Identity Service Controller', function () {
 		.catch(done.fail);
 	});
 
-	it('returns a channel object', function () {
+	it('returns a channel object', function (done) {
 		const req = {
 			params: {id: 'odd-networks'},
 			query: {},
@@ -76,10 +76,11 @@ describe('Identity Service Controller', function () {
 			expect(res.body.id).toBe('odd-networks');
 			expect(res.body.type).toBe('channel');
 			expect(res.body.title).toBe('Odd Networks');
+			done();
 		});
 	});
 
-	it('returns a platform object', function () {
+	it('returns a platform object', function (done) {
 		const req = {
 			params: {id: 'apple-ios'},
 			query: {},
@@ -91,10 +92,11 @@ describe('Identity Service Controller', function () {
 			expect(res.body.type).toBe('platform');
 			expect(res.body.channel).toBe('odd-networks');
 			expect(res.body.title).toBe('Apple iOS');
+			done();
 		});
 	});
 
-	it('updates a channel object', function () {
+	it('updates a channel object', function (done) {
 		const req = {
 			params: {id: 'odd-networks'},
 			query: {},
@@ -110,10 +112,11 @@ describe('Identity Service Controller', function () {
 			expect(res.body.type).toBe('channel');
 			expect(res.body.title).toBe('Odd');
 			expect(res.body.description).toBe('How odd are you?');
+			done();
 		});
 	});
 
-	it('updates a platform object', function () {
+	it('updates a platform object', function (done) {
 		const req = {
 			params: {id: 'apple-ios'},
 			query: {},
@@ -130,10 +133,11 @@ describe('Identity Service Controller', function () {
 			expect(res.body.channel).toBe('odd-networks');
 			expect(res.body.title).toBe('Apple iOS');
 			expect(res.body.category).toBe('MOBILE');
+			done();
 		});
 	});
 
-	it('deletes a channel object', function () {
+	it('deletes a channel object', function (done) {
 		const req = {
 			params: {id: 'odd-networks'},
 			query: {},
@@ -146,10 +150,11 @@ describe('Identity Service Controller', function () {
 			expect(res.body.type).toBeUndefined();
 			expect(res.body.title).toBeUndefined();
 			expect(res.body.description).toBeUndefined();
+			done();
 		});
 	});
 
-	it('deletes a platform object', function () {
+	it('deletes a platform object', function (done) {
 		const req = {
 			params: {id: 'apple-ios'},
 			query: {},
@@ -163,6 +168,7 @@ describe('Identity Service Controller', function () {
 			expect(res.body.channel).toBeUndefined();
 			expect(res.body.title).toBeUndefined();
 			expect(res.body.category).toBeUndefined();
+			done();
 		});
 	});
 });


### PR DESCRIPTION
This PR should satisfy #177 .

Here's the details:
- the needed logic was already present in POST to `catalog-spec-list-controller`
- added similar logic in POST to `catalog-item-controller` and `identity-list-controller`
- the logic in a PATCH to `catalog-spec-controller` was changed a small bit to match
- added similar logic to  PATCH to `catalog-item-controller` and `identity-item-controller`

Note:  the use of Jasmine's `done` was needed to make tests work for:
 - `catalog-item-controller-spec.js`
 - `identity-item-controller-spec.js`

I believe that the the spec methods and the POST methods are currently untested.

