### PR TITLE
Require Main Store for Search Stores

### DIFF
--- a/lib/stores/cloudsearch/index.js
+++ b/lib/stores/cloudsearch/index.js
@@ -50,19 +50,11 @@ module.exports = function (bus, options) {
 					return reject(err);
 				}
 
-				let items;
-
-				if (typeFilter) {
-					items = results.hits.hit.map(hit => {
-						return {type: typeFilter, id: hit.id};
+				const items = _.flatten(results.hits.hit.map(hit => {
+					return typeFilter.map(type => {
+						return {type, id: hit.id};
 					});
-				} else {
-					items = _.flatten(results.hits.hit.map(hit => {
-						return store.types.map(type => {
-							return {type, id: hit.id};
-						});
-					}));
-				}
+				}));
 
 				bus.query({role: 'store', cmd: 'batchGet', store: store.name}, {channel: payload.channel, keys: items})
 					.then(results => resolve(_.compact(results)));

--- a/lib/stores/cloudsearch/index.js
+++ b/lib/stores/cloudsearch/index.js
@@ -64,9 +64,8 @@ module.exports = function (bus, options) {
 					}));
 				}
 
-				return bus
-					.query({role: 'store', cmd: 'batchGet', store: store.name}, items)
-					.then(_.compact);
+				bus.query({role: 'store', cmd: 'batchGet', store: store.name}, {channel: payload.channel, keys: items})
+					.then(results => resolve(_.compact(results)));
 			});
 		});
 	}

--- a/lib/stores/cloudsearch/index.js
+++ b/lib/stores/cloudsearch/index.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const Promise = require('bluebird');
 
 // bus - Oddcast Bus Object
-// options.types - Array of String types *required*
+// options.store - An oddworks store instance
 // options.cloudsearchdomain - CloudSearchDomain connection Object *required*
 module.exports = function (bus, options) {
 	if (!bus || !_.isObject(bus)) {
@@ -13,10 +13,10 @@ module.exports = function (bus, options) {
 
 	options = options || {};
 	const cloudsearch = options.cloudsearch;
-	const types = options.types || ['video', 'collection'];
+	const store = options.store;
 
-	if (!Array.isArray(types) || !types.length) {
-		throw new Error('The options.types Array is required.');
+	if (!store || !_.isObject(store)) {
+		throw new Error('The options.store Object is required.');
 	}
 
 	if (!cloudsearch || !_.isObject(cloudsearch)) {
@@ -32,7 +32,7 @@ module.exports = function (bus, options) {
 			return Promise.reject(new Error('query() payload.query String is required.'));
 		}
 
-		const typeFilter = payload.type ? [payload.type] : types;
+		const typeFilter = payload.type ? [payload.type] : store.types;
 
 		const facet = {
 			channel: {buckets: [payload.channel]},
@@ -50,16 +50,28 @@ module.exports = function (bus, options) {
 					return reject(err);
 				}
 
-				const items = results.hits.hit.map(hit => {
-					return bus.query({role: 'store', cmd: 'get', type: hit.fields.type[0]}, {id: hit.id, type: hit.fields.type[0], channel: hit.fields.channel[0]});
-				});
+				let items;
 
-				return Promise.all(items).then(resolve).catch(reject);
+				if (typeFilter) {
+					items = results.hits.hit.map(hit => {
+						return {type: typeFilter, id: hit.id};
+					});
+				} else {
+					items = _.flatten(results.hits.hit.map(hit => {
+						return store.types.map(type => {
+							return {type, id: hit.id};
+						});
+					}));
+				}
+
+				return bus
+					.query({role: 'store', cmd: 'batchGet', store: store.name}, items)
+					.then(_.compact);
 			});
 		});
 	}
 
-	types.forEach(type => {
+	store.types.forEach(type => {
 		bus.commandHandler({role: 'store', cmd: 'index', type}, index);
 	});
 
@@ -69,7 +81,7 @@ module.exports = function (bus, options) {
 		name: 'cloudsearch',
 		bus,
 		options,
-		types,
+		types: store.types,
 		cloudsearch,
 		index,
 		query

--- a/lib/stores/redis-search/index.js
+++ b/lib/stores/redis-search/index.js
@@ -5,7 +5,7 @@ const Promise = require('bluebird');
 const Search = require('redis-search');
 
 // bus - Oddcast Bus Object
-// options.types - Array of String types *required*
+// options.store - An oddworks store instance
 // options.redis - Redis connection Object *required*
 // options.config - Configuration Object to pass to Search.createSearch()
 //                  https://github.com/seipop/redis-search
@@ -17,10 +17,10 @@ module.exports = function (bus, options) {
 	options = options || {};
 	const config = options.config || {};
 	const redis = options.redis;
-	const types = options.types || ['video'];
+	const store = options.store;
 
-	if (!Array.isArray(types) || !types.length) {
-		throw new Error('The options.types Array is required.');
+	if (!store || !_.isObject(store)) {
+		throw new Error('The options.store Object is required.');
 	}
 
 	if (!redis || !_.isObject(redis)) {
@@ -59,20 +59,20 @@ module.exports = function (bus, options) {
 					});
 				} else {
 					items = _.flatten(ids.map(id => {
-						return types.map(type => {
+						return store.types.map(type => {
 							return {type, id};
 						});
 					}));
 				}
 
 				return bus
-					.query({role: 'store', cmd: 'batchGet'}, items)
+					.query({role: 'store', cmd: 'batchGet', store: store.name}, items)
 					.then(_.compact);
 			});
 		});
 	}
 
-	types.forEach(type => {
+	store.types.forEach(type => {
 		bus.commandHandler({role: 'store', cmd: 'index', type}, index);
 	});
 
@@ -82,7 +82,7 @@ module.exports = function (bus, options) {
 		name: 'redis-search',
 		bus,
 		options,
-		types,
+		types: store.types,
 		search,
 		redis,
 		index,

--- a/lib/stores/redis-search/index.js
+++ b/lib/stores/redis-search/index.js
@@ -46,6 +46,7 @@ module.exports = function (bus, options) {
 	}
 
 	function query(payload) {
+		const channel = payload.channel;
 		const query = payload.query;
 		const typeFilter = payload.type;
 
@@ -69,9 +70,8 @@ module.exports = function (bus, options) {
 					}));
 				}
 
-				return bus
-					.query({role: 'store', cmd: 'batchGet', store: store.name}, items)
-					.then(_.compact);
+				bus.query({role: 'store', cmd: 'batchGet', store: store.name}, {channel, keys: items})
+					.then(results => resolve(_.compact(results)));
 			});
 		});
 	}

--- a/lib/stores/redis-search/index.js
+++ b/lib/stores/redis-search/index.js
@@ -31,6 +31,10 @@ module.exports = function (bus, options) {
 	const search = Search.createSearch(config);
 
 	function index(payload) {
+		if (!payload.text || !_.isString(payload.text)) {
+			return Promise.reject(new Error('index() payload.text String is required.'));
+		}
+
 		return new Promise((resolve, reject) => {
 			search.index(payload.text, payload.id, err => {
 				if (err) {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fakeredis": "~1.0.0",
     "jasmine": "~2.4.0",
     "jsonschema": "^1.1.0",
+    "mock-aws": "^1.2.3",
     "mock-express-request": "~0.1.0",
     "mock-express-response": "~0.1.0",
     "nsp": "~2.6.0",

--- a/spec/stores/cloudsearch-spec.js
+++ b/spec/stores/cloudsearch-spec.js
@@ -1,0 +1,135 @@
+/* global describe, beforeAll, it, expect */
+/* eslint prefer-arrow-callback: 0 */
+/* eslint-disable max-nested-callbacks */
+'use strict';
+
+const Promise = require('bluebird');
+const fakeredis = require('fakeredis');
+const aws = require('mock-aws');
+
+const redisStore = require('../../lib/stores/redis');
+const cloudsearchStore = require('../../lib/stores/cloudsearch');
+
+describe('Cloudsearch Store', function () {
+	const redisClient = fakeredis.createClient();
+	const cloudsearch = new aws.CloudSearchDomain({endpoint: 'http://cloudsearch.tld'});
+	let bus;
+
+	const VIDEOS = [
+		{id: 'video-1', type: 'video', title: 'Video One', channel: 'odd-networks'},
+		{id: 'video-2', type: 'video', title: 'Video Two', channel: 'odd-networks'},
+		{id: 'video-3', type: 'video', title: 'Video Three', channel: 'odd-networks'}
+	];
+
+	const COLLECTIONS = [
+		{id: 'collection-1', type: 'collection', title: 'Collection One', channel: 'odd-networks'},
+		{id: 'collection-2', type: 'collection', title: 'Collection Two', channel: 'odd-networks'},
+		{id: 'collection-3', type: 'collection', title: 'Collection Three', channel: 'odd-networks'}
+	];
+
+	const RESOURCES = VIDEOS.concat(COLLECTIONS);
+
+	const RESPONSES = {
+		videoResults: null,
+		threeResults: null,
+		noResults: null
+	};
+
+	Promise.promisifyAll(fakeredis.RedisClient.prototype);
+	Promise.promisifyAll(fakeredis.Multi.prototype);
+
+	beforeAll(function (done) {
+		bus = this.createBus();
+
+		redisStore(bus, {
+			types: ['video', 'collection'],
+			redis: redisClient
+		})
+		.then(store => {
+			return cloudsearchStore(bus, {
+				cloudsearch,
+				store
+			});
+		})
+		.then(() => {
+			return Promise.map(RESOURCES, resource => {
+				return bus.sendCommand({role: 'store', cmd: 'set', type: resource.type}, resource);
+			});
+		})
+		.then(() => {
+			aws.mock('CloudSearchDomain', 'search', {
+				hits: {
+					hit: [
+						{id: 'video-1'},
+						{id: 'video-2'},
+						{id: 'video-3'}
+					]
+				}
+			});
+
+			return bus.query({role: 'store', cmd: 'query'}, {channel: 'odd-networks', query: 'video'});
+		})
+		.then(videoResults => {
+			RESPONSES.videoResults = videoResults;
+
+			aws.restore('CloudSearchDomain');
+			aws.mock('CloudSearchDomain', 'search', {
+				hits: {
+					hit: [
+						{id: 'video-3'},
+						{id: 'collection-3'}
+					]
+				}
+			});
+
+			return bus.query({role: 'store', cmd: 'query'}, {channel: 'odd-networks', query: 'three'});
+		})
+		.then(threeResults => {
+			RESPONSES.threeResults = threeResults;
+
+			aws.restore('CloudSearchDomain');
+			aws.mock('CloudSearchDomain', 'search', {
+				hits: {
+					hit: []
+				}
+			});
+
+			return bus.query({role: 'store', cmd: 'query'}, {channel: 'odd-networks', query: 'Al is awesome'});
+		})
+		.then(noResults => {
+			RESPONSES.noResults = noResults;
+
+			aws.restore('CloudSearchDomain');
+
+			return true;
+		})
+		.then(done)
+		.catch(done.fail);
+	});
+
+	describe('"video" Results', function () {
+		it('should have 3 results of videos only', function (done) {
+			expect(RESPONSES.videoResults.length).toBe(3);
+			RESPONSES.videoResults.forEach(result => {
+				expect(result.type).toBe('video');
+			});
+			done();
+		});
+	});
+
+	describe('"three" Results', function () {
+		it('should have 2 results of a video and collection', function (done) {
+			expect(RESPONSES.threeResults.length).toBe(2);
+			expect(RESPONSES.threeResults[0].id).toBe('video-3');
+			expect(RESPONSES.threeResults[1].id).toBe('collection-3');
+			done();
+		});
+	});
+
+	describe('No Results', function () {
+		it('should have 0 results', function (done) {
+			expect(RESPONSES.noResults.length).toBe(0);
+			done();
+		});
+	});
+});

--- a/spec/stores/redis-search-spec.js
+++ b/spec/stores/redis-search-spec.js
@@ -1,33 +1,96 @@
-/* global xdescribe, describe, beforeAll, it, expect */
+/* global describe, beforeAll, it, expect */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
 
+const Promise = require('bluebird');
 const fakeredis = require('fakeredis');
 
-const redisSearchStore = require('../../lib/stores/redis-search/');
+const redisStore = require('../../lib/stores/redis');
+const redisSearchStore = require('../../lib/stores/redis-search');
 
-xdescribe('Redis Search Store', function () {
+describe('Redis Search Store', function () {
+	const redisClient = fakeredis.createClient();
 	let bus;
+
+	const VIDEOS = [
+		{id: 'video-1', type: 'video', title: 'Video One', channel: 'odd-networks'},
+		{id: 'video-2', type: 'video', title: 'Video Two', channel: 'odd-networks'},
+		{id: 'video-3', type: 'video', title: 'Video Three', channel: 'odd-networks'}
+	];
+
+	const COLLECTIONS = [
+		{id: 'collection-1', type: 'collection', title: 'Collection One', channel: 'odd-networks'},
+		{id: 'collection-2', type: 'collection', title: 'Collection Two', channel: 'odd-networks'},
+		{id: 'collection-3', type: 'collection', title: 'Collection Three', channel: 'odd-networks'}
+	];
+
+	const RESOURCES = VIDEOS.concat(COLLECTIONS);
+
+	const RESPONSES = {
+		videoResults: null,
+		threeResults: null
+	};
+
+	Promise.promisifyAll(fakeredis.RedisClient.prototype);
+	Promise.promisifyAll(fakeredis.Multi.prototype);
 
 	beforeAll(function (done) {
 		bus = this.createBus();
 
-		Promise.promisifyAll(fakeredis.RedisClient.prototype);
-		Promise.promisifyAll(fakeredis.Multi.prototype);
+		redisStore(bus, {
+			types: ['video', 'collection'],
+			redis: redisClient
+		})
+		.then(store => {
+			return redisSearchStore(bus, {
+				redis: redisClient,
+				store
+			});
+		})
+		.then(() => {
+			return Promise.map(RESOURCES, resource => {
+				return bus.sendCommand({role: 'store', cmd: 'set', type: resource.type}, resource);
+			});
+		})
+		.then(() => {
+			return Promise.map(RESOURCES, resource => {
+				return bus.sendCommand({role: 'store', cmd: 'index', type: resource.type}, {id: resource.id, text: resource.title});
+			});
+		})
+		.then(() => {
+			return bus.query({role: 'store', cmd: 'query'}, {channel: 'odd-networks', query: 'video'});
+		})
+		.then(videoResults => {
+			RESPONSES.videoResults = videoResults;
 
-		redisSearchStore
-			.initialize(bus, {
-				types: ['video', 'collection'],
-				redis: fakeredis.createClient()
-			})
-			.then(done)
-			.catch(done.fail);
+			return bus.query({role: 'store', cmd: 'query'}, {channel: 'odd-networks', query: 'three'});
+		})
+		.then(threeResults => {
+			RESPONSES.threeResults = threeResults;
+
+			return true;
+		})
+		.then(done)
+		.catch(done.fail);
 	});
 
-	describe('module', function () {
-		it('should be tested', function () {
-			expect(1).toBeTruthy();
+	describe('"video" Results', function () {
+		it('should have 3 results of videos only', function (done) {
+			expect(RESPONSES.videoResults.length).toBe(3);
+			RESPONSES.videoResults.forEach(result => {
+				expect(result.type).toBe('video');
+			});
+			done();
+		});
+	});
+
+	describe('"three" Results', function () {
+		it('should have 2 results of a video and collection', function (done) {
+			expect(RESPONSES.threeResults.length).toBe(2);
+			expect(RESPONSES.threeResults[0].id).toBe('video-3');
+			expect(RESPONSES.threeResults[1].id).toBe('collection-3');
+			done();
 		});
 	});
 });

--- a/spec/stores/redis-search-spec.js
+++ b/spec/stores/redis-search-spec.js
@@ -29,7 +29,8 @@ describe('Redis Search Store', function () {
 
 	const RESPONSES = {
 		videoResults: null,
-		threeResults: null
+		threeResults: null,
+		noResults: null
 	};
 
 	Promise.promisifyAll(fakeredis.RedisClient.prototype);
@@ -69,6 +70,11 @@ describe('Redis Search Store', function () {
 		.then(threeResults => {
 			RESPONSES.threeResults = threeResults;
 
+			return bus.query({role: 'store', cmd: 'query'}, {channel: 'odd-networks', query: 'Al is awesome'});
+		})
+		.then(noResults => {
+			RESPONSES.noResults = noResults;
+
 			return true;
 		})
 		.then(done)
@@ -90,6 +96,13 @@ describe('Redis Search Store', function () {
 			expect(RESPONSES.threeResults.length).toBe(2);
 			expect(RESPONSES.threeResults[0].id).toBe('video-3');
 			expect(RESPONSES.threeResults[1].id).toBe('collection-3');
+			done();
+		});
+	});
+
+	describe('No Results', function () {
+		it('should have 0 results', function (done) {
+			expect(RESPONSES.noResults.length).toBe(0);
 			done();
 		});
 	});


### PR DESCRIPTION
This obviously still needs tests, but illustrates the idea mentioned in #185 to require a main store be initialized and passed into a search store so it can use its types and store name so it knows which canonical store to get full objects from when results come back.