### PR TITLE
Additional Tests for Issue 160

### DIFF
--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -535,7 +535,6 @@ describe('Middleware Response JSON API', function () {
 		});
 	});
 
-<<<<<<< HEAD
 	describe('with partial included resourses present', function () {
 		let req = null;
 		let res = null;
@@ -566,7 +565,35 @@ describe('Middleware Response JSON API', function () {
 						// console.log('RESULT:  ', JSON.stringify(result, ' ', 2));
 						res.body = result;
 					});
-=======
+				})
+				.then(() => {
+					return middleware(req, res, err => {
+						if (err) {
+							return done.fail(err);
+						}
+						done();
+					});
+				})
+				.then(_.noop)
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('formats response body to valid jsonapi.org schema', function () {
+			const v = Validator.validate(res.body, jsonApiSchema);
+			expect(v.valid).toBe(true);
+		});
+
+		it('has only present entities in the included array', function () {
+			// console.log('RES.BODY:  ', JSON.stringify(res.body, ' ', 2));
+			// console.log('INCLUDED:  ', JSON.stringify(res.body.included, ' ', 2));
+			// console.log('ENTITIES.DATA:  ', JSON.stringify(res.body.data.relationships.entities.data, ' ', 2));
+			expect(res.body.included).toBeDefined();
+			expect(res.body.included.length).toBe(3);
+			expect(res.body.included.length).toBe(res.body.data.relationships.entities.data.length);
+		});
+	});
+
 	describe('with an empty response', function () {
 		let req = null;
 		let res = null;
@@ -585,17 +612,13 @@ describe('Middleware Response JSON API', function () {
 				.then(() => {
 					// from stores/redis, this is the response from an empty search
 					res.body = [];
->>>>>>> 4c2d021ab8cb9a45b6671a6d9c56c0651cbb8413
 				})
 				.then(() => {
 					return middleware(req, res, err => {
 						if (err) {
 							return done.fail(err);
 						}
-<<<<<<< HEAD
-=======
 						RESPONSES.SEARCH = res;
->>>>>>> 4c2d021ab8cb9a45b6671a6d9c56c0651cbb8413
 						done();
 					});
 				})
@@ -604,25 +627,9 @@ describe('Middleware Response JSON API', function () {
 				.catch(done.fail);
 		});
 
-<<<<<<< HEAD
-		it('formats response body to valid jsonapi.org schema', function () {
-			const v = Validator.validate(res.body, jsonApiSchema);
-			expect(v.valid).toBe(true);
-		});
-
-		it('has only present entities in the included array', function () {
-			// console.log('RES.BODY:  ', JSON.stringify(res.body, ' ', 2));
-			// console.log('INCLUDED:  ', JSON.stringify(res.body.included, ' ', 2));
-			// console.log('ENTITIES.DATA:  ', JSON.stringify(res.body.data.relationships.entities.data, ' ', 2));
-			expect(res.body.included).toBeDefined();
-			expect(res.body.included.length).toBe(3);
-			expect(res.body.included.length).toBe(res.body.data.relationships.entities.data.length);
-		});
-=======
 		it('returns an empty data array', function () {
 			const v = Validator.validate(RESPONSES.SEARCH.body, jsonApiSchema);
 			expect(v.valid).toBe(true);
 		});
->>>>>>> 4c2d021ab8cb9a45b6671a6d9c56c0651cbb8413
 	});
 });

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -17,9 +17,13 @@ const responseJsonApi = require('../../lib/middleware/response-json-api');
 const jsonApiSchema = require('../helpers/json-api-schema.json');
 
 const COLLECTION = require('../fixtures/collections/collection-0.json');
+const COLLECTION_1 = require('../fixtures/collections/collection-1.json');
 const REL_0 = require('../fixtures/videos/video-0.json');
 const REL_1 = require('../fixtures/videos/video-1.json');
 const REL_2 = require('../fixtures/videos/video-2.json');
+const REL_A = require('../fixtures/videos/video-a.json');
+const REL_B = require('../fixtures/videos/video-b.json');
+const REL_C = require('../fixtures/videos/video-c.json');
 
 const Validator = new JSONSchemaValidator();
 
@@ -74,7 +78,11 @@ describe('Middleware Response JSON API', function () {
 					bus.sendCommand({role, cmd, type: 'video'}, REL_0),
 					bus.sendCommand({role, cmd, type: 'video'}, REL_1),
 					bus.sendCommand({role, cmd, type: 'video'}, REL_2),
-					bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION)
+					bus.sendCommand({role, cmd, type: 'video'}, REL_A),
+					bus.sendCommand({role, cmd, type: 'video'}, REL_B),
+					bus.sendCommand({role, cmd, type: 'video'}, REL_C),
+					bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION),
+					bus.sendCommand({role, cmd, type: 'collection'}, COLLECTION_1)
 				]);
 			})
 			.then(_.noop)
@@ -138,6 +146,59 @@ describe('Middleware Response JSON API', function () {
 
 		it('adds a meta block', function () {
 			expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'APPLE_TV'});
+		});
+	});
+
+	describe('with two collections', function () {
+		let req = null;
+		let res = null;
+		let middleware = null;
+
+		beforeAll(function (done) {
+			req = _.cloneDeep(REQ);
+			res = new MockExpressResponse();
+			middleware = responseJsonApi({bus});
+			req.url = 'https://localhost:3000/collections';
+
+			return Promise.resolve(null)
+				// Load seed data (without using include)
+				.then(() => {
+					// emulates GET /collections
+					const role = 'catalog';
+					const cmd = 'fetchItemList';
+					const type = 'collection';
+
+					const args = {
+						channel: {id: 'channel-id'},
+						type,
+						id: COLLECTION.id,
+						platform: 'platform-id'
+					};
+
+					return bus.query({role, cmd, type}, args).then(result => {
+						res.body = result;
+					});
+				})
+				.then(() => {
+					return middleware(req, res, err => {
+						if (err) {
+							return done.fail(err);
+						}
+						done();
+					});
+				})
+				.then(_.noop)
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('formats response body to valid jsonapi.org schema', function () {
+			const v = Validator.validate(res.body, jsonApiSchema);
+			expect(v.valid).toBe(true);
+		});
+
+		it('has no included array', function () {
+			expect(res.body.included).not.toBeDefined();
 		});
 	});
 
@@ -471,6 +532,65 @@ describe('Middleware Response JSON API', function () {
 
 		it('excludes port from self link', function () {
 			expect(res.body.links.self).toBe('https://example.com/collections/collection-0');
+		});
+	});
+
+	describe('with partial included resourses present', function () {
+		let req = null;
+		let res = null;
+		let middleware = null;
+
+		beforeAll(function (done) {
+			req = _.cloneDeep(REQ);
+			req.query = {include: 'entities'};
+			res = new MockExpressResponse();
+			middleware = responseJsonApi({bus});
+
+			return Promise.resolve(null)
+				// Load seed data (without using include)
+				.then(() => {
+					const role = 'store';
+					const cmd = 'get';
+					const type = 'collection';
+
+					const args = {
+						channel: 'channel-id',
+						type,
+						id: COLLECTION_1.id,
+						platform: 'platform-id',
+						include: ['entities']
+					};
+
+					return bus.query({role, cmd, type}, args).then(result => {
+						// console.log('RESULT:  ', JSON.stringify(result, ' ', 2));
+						res.body = result;
+					});
+				})
+				.then(() => {
+					return middleware(req, res, err => {
+						if (err) {
+							return done.fail(err);
+						}
+						done();
+					});
+				})
+				.then(_.noop)
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('formats response body to valid jsonapi.org schema', function () {
+			const v = Validator.validate(res.body, jsonApiSchema);
+			expect(v.valid).toBe(true);
+		});
+
+		it('has only present entities in the included array', function () {
+			// console.log('RES.BODY:  ', JSON.stringify(res.body, ' ', 2));
+			// console.log('INCLUDED:  ', JSON.stringify(res.body.included, ' ', 2));
+			// console.log('ENTITIES.DATA:  ', JSON.stringify(res.body.data.relationships.entities.data, ' ', 2));
+			expect(res.body.included).toBeDefined();
+			expect(res.body.included.length).toBe(3);
+			expect(res.body.included.length).toBe(res.body.data.relationships.entities.data.length);
 		});
 	});
 });


### PR DESCRIPTION
For Issue #160, this PR adds the following tests:
- tests GET of `/collections` to ensure that there is no `included` array.
- tests GET of `/collections/:id?include=entities` to make sure that the following is true:
    - a collection with many entities
    - but only 3 of the entities are actually in the db
    - when fetched with `?include=entities`
    - only has the existing entities in the `included` Array
    - and only has the existing entities in the `obj.relationships.entities.data` array