### PR TITLE
Admin channel check

### DIFF
--- a/lib/controllers/controller.js
+++ b/lib/controllers/controller.js
@@ -15,3 +15,61 @@ exports.create = function createController(controller) {
 		}
 	};
 };
+
+class Controller {
+	fetchChannel(args) {
+		let promise;
+		if (args.req.identity.channel) {
+			promise = Promise.resolve(args.req.identity.channel);
+		} else if (args.channelId) {
+			promise = args.bus.query(
+				{role: 'store', cmd: 'get', type: 'channel'},
+				{type: 'channel', id: args.channelId}
+			);
+		} else {
+			return args.next(Boom.badData('"channel" is required'));
+		}
+		return promise;
+	}
+
+	getFetchChannel() {
+
+	}
+
+	patchFetchChannel(args) {
+		let channelId = (args.req.identity.channel || {}).id;
+
+		if (!channelId && (args.req.identity.audience || []).indexOf('admin') >= 0) {
+			channelId = (args.req.body.channel || {}).id;
+
+			if (!channelId) {
+				return args.next(Boom.badData('On admin patch request, a channel object on the payload is required'));
+			}
+		}
+		args.channelId = channelId;
+		return this.fetchChannel(args);
+	}
+
+	postGetChannel() {
+
+	}
+
+	deleteFetchChanel() {
+
+	}
+
+	static createController(controller) {
+		return function requestHandler(req, res, next) {
+			const method = req.method.toLowerCase();
+			const handler = controller[method];
+
+			if (_.isFunction(handler)) {
+				handler.call(controller, req, res, next); /* eslint-disable-line prefer-reflect */
+			} else {
+				next(Boom.methodNotAllowed());
+			}
+		};
+	}
+}
+
+module.exports = Controller;

--- a/lib/controllers/controller.js
+++ b/lib/controllers/controller.js
@@ -50,6 +50,21 @@ class Controller {
 		return this.fetchChannel(args);
 	}
 
+	patchIdentityFetchChannel(args) {
+		let channelId = (args.req.identity.channel || {}).id;
+
+		if (!channelId && (args.req.identity.audience || []).indexOf('admin') >= 0) {
+			const payload = args.req.body;
+			channelId = payload.channel || payload.id;
+
+			if (!channelId) {
+				return args.next(Boom.badData('On admin patch request for an identity object, a payload.channel or payload.id is required'));
+			}
+		}
+		args.channelId = channelId;
+		return this.fetchChannel(args);
+	}
+
 	postGetChannel() {
 
 	}

--- a/lib/controllers/controller.js
+++ b/lib/controllers/controller.js
@@ -32,8 +32,18 @@ class Controller {
 		return promise;
 	}
 
-	getFetchChannel() {
+	getFetchChannel(args) {
+		let channelId = (args.req.identity.channel || {}).id;
 
+		if (!channelId && (args.req.identity.audience || []).indexOf('admin') >= 0) {
+			channelId = args.req.query.channel || '';
+
+			if (!channelId) {
+				return args.next(Boom.badData('On admin get request, query.channel is required'));
+			}
+		}
+		args.channelId = channelId;
+		return this.fetchChannel(args);
 	}
 
 	patchFetchChannel(args) {

--- a/lib/controllers/controller.js
+++ b/lib/controllers/controller.js
@@ -65,8 +65,18 @@ class Controller {
 		return this.fetchChannel(args);
 	}
 
-	postGetChannel() {
+	postFetchChannel(args) {
+		let channelId = (args.req.identity.channel || {}).id;
 
+		if (!channelId && (args.req.identity.audience || []).indexOf('admin') >= 0) {
+			channelId = args.req.body.channel;
+
+			if (!channelId) {
+				return args.next(Boom.badData('On admin post request, payload.channel is required'));
+			}
+		}
+		args.channelId = channelId;
+		return this.fetchChannel(args);
 	}
 
 	deleteFetchChanel() {

--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -107,7 +107,6 @@ class CatalogItemController {
 	}
 
 	static create(spec) {
-		console.log('poop');
 		if (!spec.bus || !_.isObject(spec.bus)) {
 			throw new Error('CatalogItemController spec.bus is required');
 		}

--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -3,7 +3,9 @@
 const _ = require('lodash');
 const Boom = require('boom');
 
-const controller = require('../../../controllers/controller');
+const Controller = require('../../../controllers/controller');
+
+const controller = new Controller();
 
 class CatalogItemController {
 	constructor(spec) {
@@ -63,23 +65,6 @@ class CatalogItemController {
 		const payload = req.body;
 		let channelId = (req.identity.channel || {}).id;
 
-		// only allow channel from the payload from an admin
-		if (!channelId && (req.identity.audience || []).indexOf('admin') >= 0) {
-			channelId = (payload.channel || {}).id;
-		}
-
-		let promise;
-		if (req.identity.channel) {
-			promise = Promise.resolve(req.identity.channel);
-		} else if (channelId) {
-			promise = this.bus.query(
-				{role: 'store', cmd: 'get', type: 'channel'},
-				{type: 'channel', id: channelId}
-			);
-		} else {
-			return next(Boom.badData('"channel" is required'));
-		}
-
 		const args = {
 			type: this.type,
 			id: req.params.id,
@@ -87,11 +72,12 @@ class CatalogItemController {
 			viewer: req.identity.viewer
 		};
 
-		return promise
+		return controller.patchFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {
 					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
 				}
+				channelId = channel.id;
 				args.channel = channel;
 				return this.bus.query({role: 'catalog', cmd: 'fetchItem'}, args);
 			})
@@ -138,6 +124,7 @@ class CatalogItemController {
 	}
 
 	static create(spec) {
+		console.log('poop');
 		if (!spec.bus || !_.isObject(spec.bus)) {
 			throw new Error('CatalogItemController spec.bus is required');
 		}
@@ -145,7 +132,7 @@ class CatalogItemController {
 			throw new Error('CatalogItemController spec.type is required');
 		}
 
-		return controller.create(new CatalogItemController(spec));
+		return controller.createController(new CatalogItemController(spec));
 	}
 }
 

--- a/lib/services/catalog/controllers/catalog-item-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-controller.js
@@ -14,12 +14,7 @@ class CatalogItemController {
 	}
 
 	get(req, res, next) {
-		let channelId = (req.identity.channel || {}).id;
-
-		// only allow channel from the queryString from an admin
-		if (!channelId && (req.identity.audience || []).indexOf('admin') >= 0) {
-			channelId = req.query.channel || '';
-		}
+		const channelId = (req.identity.channel || {}).id;
 
 		const args = {
 			type: this.type,
@@ -32,19 +27,7 @@ class CatalogItemController {
 			args.include = req.query.include.split(',');
 		}
 
-		let promise;
-		if (req.identity.channel) {
-			promise = Promise.resolve(req.identity.channel);
-		} else if (channelId) {
-			promise = this.bus.query(
-				{role: 'store', cmd: 'get', type: 'channel'},
-				{type: 'channel', id: channelId}
-			);
-		} else {
-			return next(Boom.badRequest('"channel" is required'));
-		}
-
-		return promise
+		return controller.getFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {
 					return next(Boom.conflict(`Channel ${channelId} does not exist.`));

--- a/lib/services/catalog/controllers/catalog-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-list-controller.js
@@ -3,7 +3,9 @@
 const _ = require('lodash');
 const Boom = require('boom');
 
-const controller = require('../../../controllers/controller');
+const Controller = require('../../../controllers/controller');
+
+const controller = new Controller();
 
 class CatalogListController {
 	constructor(spec) {
@@ -64,21 +66,19 @@ class CatalogListController {
 	post(req, res, next) {
 		const payload = _.cloneDeep(req.body || {});
 		const type = this.type;
-		let channelId = (req.identity.channel || {}).id;
+		const channelId = (req.identity.channel || {}).id;
 
-		// only allow channel from the payload from an admin
-		if (!channelId && (req.identity.audience || []).indexOf('admin') >= 0) {
-			channelId = payload.channel || '';
-		}
+		return controller.postFetchChannel({req, next, bus: this.bus})
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
 
-		if (!channelId) {
-			return next(Boom.badData('"channel" is required'));
-		}
+				payload.channel = channel.id;
+				payload.type = type;
 
-		payload.channel = channelId;
-		payload.type = type;
-
-		return this.bus.sendCommand({role: 'catalog', cmd: 'setItem'}, payload)
+				return this.bus.sendCommand({role: 'catalog', cmd: 'setItem'}, payload);
+			})
 			.then(resource => {
 				res.body = resource;
 				res.status(201);

--- a/lib/services/catalog/controllers/catalog-spec-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-spec-list-controller.js
@@ -4,7 +4,9 @@ const Promise = require('bluebird');
 const _ = require('lodash');
 const Boom = require('boom');
 
-const controller = require('../../../controllers/controller');
+const Controller = require('../../../controllers/controller');
+
+const controller = new Controller();
 
 class CatalogItemSpecListController {
 	constructor(spec) {
@@ -51,21 +53,18 @@ class CatalogItemSpecListController {
 	post(req, res, next) {
 		const type = this.type;
 		const payload = _.cloneDeep(req.body || {});
-		let channelId = (req.identity.channel || {}).id;
+		const channelId = (req.identity.channel || {}).id;
 
-		// only allow channel from the payload from an admin
-		if (!channelId && (req.identity.audience || []).indexOf('admin') >= 0) {
-			channelId = payload.channel;
-		}
+		return controller.postFetchChannel({req, next, bus: this.bus})
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+				payload.channel = channel.id;
+				payload.type = type;
 
-		if (!channelId) {
-			return next(Boom.badData('"channel" is required'));
-		}
-
-		payload.channel = channelId;
-		payload.type = type;
-
-		return this.bus.sendCommand({role: 'catalog', cmd: 'setItemSpec'}, payload)
+				return this.bus.sendCommand({role: 'catalog', cmd: 'setItemSpec'}, payload);
+			})
 			.then(resource => {
 				res.body = resource;
 				res.status(201);

--- a/lib/services/identity/controllers/identity-item-controller.js
+++ b/lib/services/identity/controllers/identity-item-controller.js
@@ -3,7 +3,9 @@
 const _ = require('lodash');
 const Boom = require('boom');
 
-const controller = require('../../../controllers/controller');
+const Controller = require('../../../controllers/controller');
+
+const controller = new Controller();
 
 class IdentityItemController {
 	constructor(spec) {
@@ -45,39 +47,20 @@ class IdentityItemController {
 	patch(req, res, next) {
 		const type = this.type;
 		const payload = req.body;
-		let channelId = (req.identity.channel || {}).id;
-
-		// only allow channel from the payload from an admin
-		if (!channelId && (req.identity.audience || []).indexOf('admin') >= 0) {
-			channelId = type === 'channel' ? payload.id : payload.channel;
-		}
-
-		if (type !== 'channel' && !channelId) {
-			return next(Boom.badData('"channel" is required'));
-		}
+		let channelId;
 
 		const args = {
 			type,
 			id: req.params.id
 		};
 
-		let promise;
-		if (req.identity.channel) {
-			promise = Promise.resolve(req.identity.channel);
-		} else if (channelId) {
-			promise = this.bus.query(
-				{role: 'store', cmd: 'get', type: 'channel'},
-				{type: 'channel', id: channelId}
-			);
-		} else {
-			return next(Boom.badData('"channel" is required'));
-		}
-
-		return promise
+		return controller.patchIdentityFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {
 					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
 				}
+
+				channelId = channel.id;
 
 				if (type !== 'channel') {
 					args.channel = channel.id;

--- a/lib/services/identity/controllers/identity-list-controller.js
+++ b/lib/services/identity/controllers/identity-list-controller.js
@@ -3,7 +3,9 @@
 const _ = require('lodash');
 const Boom = require('boom');
 
-const controller = require('../../../controllers/controller');
+const Controller = require('../../../controllers/controller');
+
+const controller = new Controller();
 
 class IdentityListController {
 	constructor(spec) {
@@ -36,12 +38,9 @@ class IdentityListController {
 		payload.type = type;
 		let channelId = (req.identity.channel || {}).id;
 
-		// only allow channel from the payload from an admin
+		// TODO should none admin audience be able to post a new channel?
 		if (type === 'channel') {
 			channelId = payload.id;
-		}
-		if (!channelId && (req.identity.audience || []).indexOf('admin') >= 0) {
-			channelId = payload.channel;
 		}
 
 		if (type === 'channel') {
@@ -55,19 +54,7 @@ class IdentityListController {
 				.catch(next);
 		}
 
-		let promise;
-		if (req.identity.channel) {
-			promise = Promise.resolve(req.identity.channel);
-		} else if (channelId) {
-			promise = this.bus.query(
-				{role: 'store', cmd: 'get', type: 'channel'},
-				{type: 'channel', id: channelId}
-			);
-		} else {
-			return next(Boom.badData('"channel" is required'));
-		}
-
-		return promise
+		return controller.postFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {
 					return next(Boom.conflict(`Channel ${channelId} does not exist.`));

--- a/lib/services/identity/controllers/identity-list-controller.js
+++ b/lib/services/identity/controllers/identity-list-controller.js
@@ -38,7 +38,7 @@ class IdentityListController {
 		payload.type = type;
 		let channelId = (req.identity.channel || {}).id;
 
-		// TODO should none admin audience be able to post a new channel?
+		// TODO should non-admin audience be able to post a new channel?
 		if (type === 'channel') {
 			channelId = payload.id;
 		}


### PR DESCRIPTION
This PR refactors out the channel checking logic from the write endpoints, and catalog-item GET that were inserted in issue #177.

Details:
 - The main controller gets some methods to handle checking the channel.  
 - I'll make a few notes in the code to point out a few concerns.