### PR TITLE
return removeItem as object instead of bool

### DIFF
--- a/lib/services/catalog/queries/index.js
+++ b/lib/services/catalog/queries/index.js
@@ -209,7 +209,7 @@ module.exports = function (service) {
 				return service.bus.sendCommand(
 					{role: 'catalog', cmd: 'removeItem', type},
 					object
-				);
+				).then(_.constant(object));
 			});
 	}
 


### PR DESCRIPTION
NOTE:  all tests pass with this PR.

However,  I did a local code coverage check with `istanbul` locally and this line isn't covered.

I will probably need a hand figuring out the best way to test that the retruned object is `typeof === 'object'`  and  `typeof !== 'bool'`