### PR TITLE
CollectionSpec Error Handling

### DIFF
--- a/lib/services/catalog/commands/index.js
+++ b/lib/services/catalog/commands/index.js
@@ -14,10 +14,13 @@ module.exports = function (service) {
 		payload = _.cloneDeep(payload);
 
 		if (!payload.channel || !_.isString(payload.channel)) {
-			throw new Error('payload.channel is required');
+			Promise.reject(new Error('payload.channel is required'));
+		}
+		if (!payload.source || !_.isString(payload.source)) {
+			Promise.reject(new Error('spec.source String is required'));
 		}
 		if (!payload.type || !_.isString(payload.type)) {
-			throw new Error('payload.type is required');
+			Promise.reject(new Error('payload.type is required'));
 		}
 
 		payload.meta = payload.meta || {};

--- a/lib/services/catalog/commands/index.js
+++ b/lib/services/catalog/commands/index.js
@@ -73,9 +73,6 @@ module.exports = function (service) {
 		if (!spec.channel || !_.isString(spec.channel)) {
 			throw new Error('spec.channel String is required');
 		}
-		if (!spec.source || !_.isString(spec.source)) {
-			throw new Error('spec.source String is required');
-		}
 		if (!spec.type || !_.isString(spec.type)) {
 			throw new Error('spec.type String is required');
 		}

--- a/lib/services/catalog/controllers/catalog-spec-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-spec-list-controller.js
@@ -55,6 +55,10 @@ class CatalogItemSpecListController {
 		const payload = _.cloneDeep(req.body || {});
 		const channelId = (req.identity.channel || {}).id;
 
+		if (!payload.source || !_.isString(payload.source)) {
+			return next(Boom.conflict(`${type}.source (string) is required.`));
+		}
+
 		return controller.postFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {

--- a/lib/services/catalog/controllers/catalog-spec-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-spec-list-controller.js
@@ -55,10 +55,6 @@ class CatalogItemSpecListController {
 		const payload = _.cloneDeep(req.body || {});
 		const channelId = (req.identity.channel || {}).id;
 
-		if (!payload.source || !_.isString(payload.source)) {
-			return next(Boom.conflict(`${type}.source (string) is required.`));
-		}
-
 		return controller.postFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {
@@ -67,14 +63,17 @@ class CatalogItemSpecListController {
 				payload.channel = channel.id;
 				payload.type = type;
 
-				return this.bus.sendCommand({role: 'catalog', cmd: 'setItemSpec'}, payload);
+				return this.bus.sendCommand({role: 'catalog', cmd: 'setItemSpec'}, payload)
+					.catch(err => {
+						console.log('ERR: ', err);
+						return next(Boom.badData(err.message));
+					});
 			})
 			.then(resource => {
 				res.body = resource;
 				res.status(201);
 				return next();
-			})
-			.catch(next);
+			});
 	}
 
 	static create(spec) {

--- a/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
+++ b/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
@@ -1,10 +1,12 @@
-/* global describe, beforeAll, expect, it, xdescribe */
+/* global describe, beforeAll, spyOn, expect, it, xdescribe */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
 
 const Promise = require('bluebird');
 const fakeredis = require('fakeredis');
+const MockExpressResponse = require('mock-express-response');
+const Boom = require('boom');
 const redisStore = require('../../../../lib/stores/redis/');
 const catalogService = require('../../../../lib/services/catalog');
 const identityService = require('../../../../lib/services/identity');
@@ -127,6 +129,26 @@ describe('Catalog Service fetchItem', function () {
 			expect(res.body.source).toBe('testProvider14');
 			expect(res.body.channel).toBe('odd-networks');
 			done();
+		});
+	});
+
+	describe('POST with missing .source', function () {
+		it('returns a 422 response', function (done) {
+			spyOn(Boom, 'conflict');
+			const res = new MockExpressResponse();
+			const req = {
+				query: {},
+				params: {},
+				body: COLLECTION_SPEC_14,
+				identity: {audience: 'admin'}
+			};
+
+			delete req.body.source;
+
+			this.controller.spec.post(req, res, () => {
+				expect(Boom.conflict).toHaveBeenCalledTimes(1);
+				done();
+			});
 		});
 	});
 

--- a/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
+++ b/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
@@ -152,5 +152,25 @@ describe('Catalog Service fetchItem', function () {
 		});
 	});
 
+	describe('POST with missing unsupported source', function () {
+		it('returns a 422 response', function (done) {
+			spyOn(Boom, 'conflict');
+			const res = new MockExpressResponse();
+			const req = {
+				query: {},
+				params: {},
+				body: COLLECTION_SPEC_14,
+				identity: {audience: 'admin'}
+			};
+
+			req.body.source = 'baz';
+
+			this.controller.spec.post(req, res, () => {
+				expect(Boom.conflict).toHaveBeenCalledTimes(1);
+				done();
+			});
+		});
+	});
+
 	xdescribe('Admin GET retrieves all preset specs a spec object');
 });

--- a/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
+++ b/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
@@ -134,7 +134,7 @@ describe('Catalog Service fetchItem', function () {
 
 	describe('POST with missing .source', function () {
 		it('returns a 422 response', function (done) {
-			spyOn(Boom, 'conflict');
+			spyOn(Boom, 'badData');
 			const res = new MockExpressResponse();
 			const req = {
 				query: {},
@@ -146,7 +146,7 @@ describe('Catalog Service fetchItem', function () {
 			delete req.body.source;
 
 			this.controller.spec.post(req, res, () => {
-				expect(Boom.conflict).toHaveBeenCalledTimes(1);
+				expect(Boom.badData).toHaveBeenCalledTimes(1);
 				done();
 			});
 		});
@@ -154,7 +154,7 @@ describe('Catalog Service fetchItem', function () {
 
 	describe('POST with missing unsupported source', function () {
 		it('returns a 422 response', function (done) {
-			spyOn(Boom, 'conflict');
+			spyOn(Boom, 'badData');
 			const res = new MockExpressResponse();
 			const req = {
 				query: {},
@@ -166,7 +166,7 @@ describe('Catalog Service fetchItem', function () {
 			req.body.source = 'baz';
 
 			this.controller.spec.post(req, res, () => {
-				expect(Boom.conflict).toHaveBeenCalledTimes(1);
+				expect(Boom.badData).toHaveBeenCalledTimes(1);
 				done();
 			});
 		});


### PR DESCRIPTION
This PR is for Issue #173.

The first two commits are OK.

The 3rd commit is for this portion of the issue:
>This is expected, but the response code should be 422 and the error message should be more informative like "The provider source 'foo' is not supported".


The stated error above seems to be coming from [this spot in oddcast](https://github.com/oddnetworks/oddcast/blob/1bb11c03d54b08cc76576287fd36d0b5eed7a44b/lib/inprocess-transport.js#L28-L30).

I can't seem to detect the error in Oddworks tests.  

I'm wondering:
(1) Is Oddworks handling Oddcast errors in the intended way?
(2) Should we try to bring these errors into Oddworks?
