### PR TITLE
For #201 - Restricts POST of channel to admin token

### DIFF
--- a/lib/services/identity/controllers/identity-list-controller.js
+++ b/lib/services/identity/controllers/identity-list-controller.js
@@ -36,14 +36,13 @@ class IdentityListController {
 		const type = this.type;
 		const payload = _.cloneDeep(req.body || {});
 		payload.type = type;
-		let channelId = (req.identity.channel || {}).id;
-
-		// TODO should non-admin audience be able to post a new channel?
-		if (type === 'channel') {
-			channelId = payload.id;
-		}
+		const channelId = (req.identity.channel || {}).id;
 
 		if (type === 'channel') {
+			if ((req.identity.audience || []).indexOf('admin') < 0) {
+				return next(Boom.forbidden('Only an admin token can POST a new channel'));
+			}
+
 			return this.bus
 				.sendCommand({role: 'store', cmd: 'set', type}, payload)
 				.then(resource => {

--- a/spec/services/identity/controllers/admin-identity-list-controller-spec.js
+++ b/spec/services/identity/controllers/admin-identity-list-controller-spec.js
@@ -1,8 +1,9 @@
-/* global describe, beforeAll, expect, it, xdescribe */
+/* global describe, beforeAll, expect, it, spyOn, xdescribe */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
 
+const Boom = require('boom');
 const Promise = require('bluebird');
 const fakeredis = require('fakeredis');
 const redisStore = require('../../../../lib/stores/redis/');
@@ -92,6 +93,25 @@ describe('Identity Service Controller', function () {
 		});
 	});
 
+	it('non-Admin POST of channel recieves a forbidden response', function (done) {
+		const res = {
+			body: {},
+			status() {
+			}
+		};
+		const req = {
+			query: {},
+			params: {},
+			body: CHANNEL_2,
+			identity: {audience: 'platform'}
+		};
+		spyOn(Boom, 'forbidden');
+
+		this.controller.channel.post(req, res, () => {
+			expect(Boom.forbidden).toHaveBeenCalledTimes(1);
+			done();
+		});
+	});
 	it('Admin POST inserts a platform object', function (done) {
 		const res = {
 			body: {},


### PR DESCRIPTION
This PR should satisfy #201.

Here we:

- restrict the POST of a channel to an admin token
- and test out the `forbidden` response`.