### PR TITLE
Admin token GET items

### DIFF
--- a/lib/services/catalog/controllers/catalog-spec-controller.js
+++ b/lib/services/catalog/controllers/catalog-spec-controller.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('bluebird');
 const _ = require('lodash');
 const Boom = require('boom');
 
@@ -17,8 +16,7 @@ class CatalogItemSpecController {
 	get(req, res, next) {
 		const type = this.type;
 		const id = req.params.id;
-		const channel = req.identity.channel;
-		const channelId = req.query.channel;
+		const channelId = (req.identity.channel || {}).id;
 
 		if (req.query.include) {
 			return next(Boom.badRequest(
@@ -26,19 +24,7 @@ class CatalogItemSpecController {
 			));
 		}
 
-		let promise;
-		if (channel) {
-			promise = Promise.resolve(channel);
-		} else if (channelId) {
-			promise = this.bus.query(
-				{role: 'store', cmd: 'get', type: 'channel'},
-				{type: 'channel', id: channelId}
-			);
-		} else {
-			return next(Boom.badRequest('channel parameter is required'));
-		}
-
-		return promise
+		return controller.getFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
 				if (!channel) {
 					return next(Boom.conflict(`channel ${channelId} does not exist`));

--- a/lib/services/identity/controllers/identity-item-controller.js
+++ b/lib/services/identity/controllers/identity-item-controller.js
@@ -15,23 +15,24 @@ class IdentityItemController {
 
 	get(req, res, next) {
 		const type = this.type;
-		const channel = (req.identity.channel || {}).id || req.query.channel;
+		const id = req.params.id;
+		const channelId = (req.identity.channel || {}).id;
 
-		if (type !== 'channel' && !channel) {
-			return next(Boom.badRequest('channel parameter is required'));
-		}
+		return controller.getFetchChannel({req, next, bus: this.bus})
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`channel ${channelId} does not exist`));
+				}
+				// cannot simply return the channel here
+				// on non-admin requests for the channel we still need to get the channel from the store
+				const args = {type, id};
 
-		const args = {
-			type,
-			id: req.params.id
-		};
+				if (type !== 'channel') {
+					args.channel = channel.id;
+				}
 
-		if (type !== 'channel') {
-			args.channel = channel;
-		}
-
-		return this.bus
-			.query({role: 'store', cmd: 'get', type}, args)
+				return this.bus.query({role: 'store', cmd: 'get', type}, args);
+			})
 			.then(resource => {
 				if (!resource) {
 					return next(Boom.notFound('resource not found'));

--- a/spec/services/catalog/controllers/admin-catalog-spec-controller-spec.js
+++ b/spec/services/catalog/controllers/admin-catalog-spec-controller-spec.js
@@ -101,7 +101,32 @@ describe('Catalog Service fetchItem', function () {
 		.catch(done.fail);
 	});
 
-	xdescribe('Admin GET fetches a spec object');
+	describe('Admin GET', function () {
+		it('fetches a spec object', function (done) {
+			const req = {
+				params: {id: 'collection-13-spec'},
+				identity: {
+					audience: 'admin',
+					platform: {id: 'apple-ios'},
+					user: {id: 'user-id'}
+				},
+				query: {channel: 'odd-networks'}
+			};
+			const res = {
+				body: {},
+				status() {
+				}
+			};
+
+			this.controller.spec.get(req, res, () => {
+				expect(res.body.id).toBe('collection-13-spec');
+				expect(res.body.type).toBe('collectionSpec');
+				expect(res.body.source).toBe('testProvider');
+				expect(res.body.channel).toBe('odd-networks');
+				done();
+			});
+		});
+	});
 
 	describe('Admin PATCH updates a spec object', function () {
 		it('Admin PATCH updates a spec object', function (done) {

--- a/spec/services/identity/controllers/admin-identity-item-controller-spec.js
+++ b/spec/services/identity/controllers/admin-identity-item-controller-spec.js
@@ -65,9 +65,36 @@ describe('Identity Service Controller', function () {
 		.catch(done.fail);
 	});
 
-	xdescribe('Admin GET returns a channel object');
+	describe('Admin GET', function () {
+		it('returns a channel object', function (done) {
+			const req = {
+				query: {channel: 'odd-networks'},
+				params: {id: 'odd-networks'},
+				identity: {audience: 'admin'}
+			};
 
-	xdescribe('Admin GET returns a platform object');
+			this.controller.channel.get(req, res, () => {
+				expect(res.body.id).toBe('odd-networks');
+				expect(res.body.title).toBe('Odd Networks');
+				done();
+			});
+		});
+
+		it('returns a platform object', function (done) {
+			const req = {
+				query: {channel: 'odd-networks'},
+				params: {id: 'apple-ios'},
+				identity: {audience: 'admin'}
+			};
+
+			this.controller.platform.get(req, res, () => {
+				expect(res.body.id).toBe('apple-ios');
+				expect(res.body.title).toBe('Apple iOS');
+				expect(res.body.channel).toBe('odd-networks');
+				done();
+			});
+		});
+	});
 
 	it('Admin PATCH updates a channel object', function (done) {
 		const req = {


### PR DESCRIPTION
This PR is for Issue #202. 

All GET endpoints of `/{type}s/:id` should now be functional with an admin token, with tests.