### PR TITLE
Fixing the Relationships endpoint response

### DIFF
--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -134,37 +134,49 @@ module.exports = function (options) {
 		let data;
 
 		if (_.isArray(res.body)) {
-			let baseSelfLink;
-			const linksQueries = res.body.linksQueries;
-			if (res.body.length === 0) {
+			const regex = /\/relationships\//;
+			if (regex.test(req.url.toLowerCase())) {
+				const data = _.cloneDeep(res.body);
 				res.body = {
-					data: []
+					data
 				};
-				baseSelfLink = `${baseUrl}${url.parse(req.url).pathname}`;
+				res.body.links = {
+					self: `${baseUrl}${req.url}`
+				};
+				next();
 			} else {
-				data = res.body.slice();
-				res.body = {};
+				let baseSelfLink;
+				const linksQueries = res.body.linksQueries;
+				if (res.body.length === 0) {
+					res.body = {
+						data: []
+					};
+					baseSelfLink = `${baseUrl}${url.parse(req.url).pathname}`;
+				} else {
+					data = res.body.slice();
+					res.body = {};
 
-				res.body.data = data.map(object => {
-					delete object.included;
-					return format(object, baseUrl);
-				});
+					res.body.data = data.map(object => {
+						delete object.included;
+						return format(object, baseUrl);
+					});
 
-				baseSelfLink = `${baseUrl}/${data[0].type}s`;
-			}
+					baseSelfLink = `${baseUrl}/${data[0].type}s`;
+				}
 
-			const query = url.parse(req.url).query;
-			const selfLink = query ? `${baseSelfLink}?${query}` : baseSelfLink;
+				const query = url.parse(req.url).query;
+				const selfLink = query ? `${baseSelfLink}?${query}` : baseSelfLink;
 
-			res.body.links = {
-				self: selfLink
-			};
+				res.body.links = {
+					self: selfLink
+				};
 
-			if (linksQueries) {
-				Object.keys(linksQueries).forEach(key => {
-					const qs = querystring.stringify(linksQueries[key]);
-					res.body.links[key] = `${baseSelfLink}?${qs}`;
-				});
+				if (linksQueries) {
+					Object.keys(linksQueries).forEach(key => {
+						const qs = querystring.stringify(linksQueries[key]);
+						res.body.links[key] = `${baseSelfLink}?${qs}`;
+					});
+				}
 			}
 		} else {
 			data = _.cloneDeep(res.body);

--- a/lib/services/catalog/controllers/catalog-item-relationship-controller.js
+++ b/lib/services/catalog/controllers/catalog-item-relationship-controller.js
@@ -82,7 +82,7 @@ class CatalogItemRelationshipController {
 						relationships.data = _.slice(relationships.data, start, end);
 					}
 
-					res.body = relationships;
+					res.body = relationships.data;
 					res.status(200);
 					next();
 				} else {

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -632,4 +632,60 @@ describe('Middleware Response JSON API', function () {
 			expect(v.valid).toBe(true);
 		});
 	});
+
+	describe('with an array from the relationships endpoint', function () {
+		const req = _.cloneDeep(REQ);
+		let res = null;
+		let middleware = null;
+		const RESPONSES = {
+			ARRAY_RES: null
+		};
+
+		beforeAll(function (done) {
+			req.url = '/collections/123/relationships/entities';
+
+			res = new MockExpressResponse();
+			res.body = [
+				{
+					id: '1',
+					type: 'video'
+				},
+				{
+					id: '2',
+					type: 'collection'
+				}
+			];
+
+			middleware = responseJsonApi({bus});
+
+			return Promise.resolve(null)
+					.then(() => {
+						return middleware(req, res, err => {
+							if (err) {
+								return done.fail(err);
+							}
+							RESPONSES.ARRAY_RES = res;
+						});
+					})
+					.then(_.noop)
+					.then(done)
+					.catch(done.fail);
+		});
+
+		it('returns a valid api response', function () {
+			const v = Validator.validate(RESPONSES.ARRAY_RES.body, jsonApiSchema);
+			expect(v.valid).toBe(true);
+		});
+
+		it('returns with the expected members in the data array', function () {
+			const data = (RESPONSES.ARRAY_RES.body || {}).data;
+			expect(data.length).toBe(2);
+			expect(data[0].id).toBe('1');
+			expect(data[0].type).toBe('video');
+			expect(data[1].id).toBe('2');
+			expect(data[1].type).toBe('collection');
+			expect(Object.keys(data[0]).length).toBe(2);
+			expect(Object.keys(data[1]).length).toBe(2);
+		});
+	});
 });

--- a/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
+++ b/spec/services/catalog/controllers/admin-spec-list-controller-spec.js
@@ -145,10 +145,11 @@ describe('Catalog Service fetchItem', function () {
 
 			delete req.body.source;
 
-			this.controller.spec.post(req, res, () => {
-				expect(Boom.badData).toHaveBeenCalledTimes(1);
-				done();
-			});
+			this.controller.spec.post(req, res, () => {})
+				.then(() => {
+					expect(Boom.badData).toHaveBeenCalledTimes(1);
+					done();
+				});
 		});
 	});
 
@@ -165,10 +166,11 @@ describe('Catalog Service fetchItem', function () {
 
 			req.body.source = 'baz';
 
-			this.controller.spec.post(req, res, () => {
-				expect(Boom.badData).toHaveBeenCalledTimes(1);
-				done();
-			});
+			this.controller.spec.post(req, res, () => {})
+				.then(() => {
+					expect(Boom.badData).toHaveBeenCalledTimes(1);
+					done();
+				});
 		});
 	});
 

--- a/spec/services/catalog/controllers/catalog-item-relationship-controller-spec.js
+++ b/spec/services/catalog/controllers/catalog-item-relationship-controller-spec.js
@@ -113,7 +113,7 @@ describe('Catalog Item Relationship Controller', function () {
 
 		this.controller.relationship.get(req, res, () => {
 			RESULTS.GET = res.body;
-			expect(res.body.data.length).toBe(3);
+			expect(res.body.length).toBe(3);
 			done();
 		});
 	});
@@ -135,7 +135,7 @@ describe('Catalog Item Relationship Controller', function () {
 		};
 
 		this.controller.relationship.get(req, res, () => {
-			const data = res.body.data;
+			const data = res.body;
 			expect(res.body.included).toBeFalsy();
 			expect(data[0].id).toBe('1111-3');
 			expect(data[1].id).toBe('1111-4');
@@ -168,7 +168,7 @@ describe('Catalog Item Relationship Controller', function () {
 		};
 
 		this.controller.relationship.get(req, res, () => {
-			const data = res.body.data;
+			const data = res.body;
 			expect(res.body.included).toBeFalsy();
 			expect(data[9].id).toBe('1111-3');
 			expect(data[8].id).toBe('1111-4');
@@ -201,7 +201,7 @@ describe('Catalog Item Relationship Controller', function () {
 		};
 
 		this.controller.relationship.get(req, res, () => {
-			const data = res.body.data;
+			const data = res.body;
 			expect(res.body.included).toBeFalsy();
 			expect(data[0].id).toBe('1111-3');
 			expect(data[1].id).toBe('1111-4');
@@ -240,7 +240,7 @@ describe('Catalog Item Relationship Controller', function () {
 		};
 
 		this.controller.relationship.get(req, res, () => {
-			const data = res.body.data;
+			const data = res.body;
 			expect(data.length).toBe(3);
 			expect(data[0].id).toBe('1111-10');
 			done();


### PR DESCRIPTION
This Should solve issue #210.

In this PR we:
- pass the correct data from the catalog-item-relationship-controller to the response-jsonapi
- fix the relationships tests to reflect the data change
- correct the output from the response-json-api
__Note: this is done with string detection on the original url.  It isn't optimal, but it solved the problem.  I'm open to suggestions on this part__ ([url to this commit)](https://github.com/oddnetworks/oddworks/commit/56bc531286abd67f90eb39f50bea8aceff836d66)

- add some tests for valid output from the relationships endpoint
- changing the tests for json-api-response cause a timing issue to rise to the surface in `admin-spec-list-controller-spec.js`.  So those were corrected too.