### PR TITLE
push up to Jasmine 2.5.2 or higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "aws-sdk": "~2.5.0",
     "dynalite": "~1.0.0",
     "fakeredis": "~1.0.0",
-    "jasmine": "~2.4.0",
+    "jasmine": "^2.5.2",
     "jsonschema": "^1.1.0",
     "mock-aws": "^1.2.3",
     "mock-express-request": "~0.1.0",


### PR DESCRIPTION
For issue #167.

The `package.json` was froze jasmine at 2.4.2 because of issues with tests running on jasmine 2.5.0.

@thisgeek seems to have correctly identified the issue.  Thanks!

Runs and works on my machine...