### PR TITLE
Viewer Auth

### DIFF
--- a/lib/services/identity/controllers/identity-login-controller.js
+++ b/lib/services/identity/controllers/identity-login-controller.js
@@ -67,6 +67,24 @@ function proxyAuth(bus, req, res, next) {
 		})
 		.then(resource => {
 			viewer = resource;
+
+			// Viewer does not exist, but proxy auth was successful so create a viewer
+			if (!viewer) {
+				viewer = {
+					id: req.body.payload.email,
+					entitlements: [],
+					relationships: {
+						platforms: {
+							data: [
+								{id: req.identity.platform.id, type: 'platform'}
+							]
+						},
+						watchlist: {data: []}
+					},
+					meta: {}
+				};
+			}
+
 			const jwt = {
 				channel: req.identity.channel.id,
 				platform: req.identity.platform.id,

--- a/lib/services/identity/controllers/identity-login-controller.js
+++ b/lib/services/identity/controllers/identity-login-controller.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const _ = require('lodash');
+const bcrypt = require('bcrypt');
+const Boom = require('boom');
+
+const Controller = require('../../../controllers/controller');
+
+const controller = new Controller();
+
+class IdentityLoginController {
+	constructor(spec) {
+		this.bus = spec.bus;
+	}
+
+	post(req, res, next) {
+		const payload = _.cloneDeep(req.body || {});
+		const channelId = (req.identity.channel || {}).id;
+		const platformId = (req.identity.platform || {}).id;
+		let viewer;
+
+		return controller.postFetchChannel({req, next, bus: this.bus})
+			.then(channel => {
+				if (!channel) {
+					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
+				}
+
+				// Fetch the viewer by channel and id (email)
+				const args = {
+					id: payload.email,
+					type: 'viewer',
+					channel: channelId
+				};
+
+				return this.bus.query({role: 'store', cmd: 'get', type: 'viewer'}, args);
+			})
+			.then(resource => {
+				viewer = resource;
+
+				// Verify the password is correct
+				if (!bcrypt.compareSync(payload.password, viewer.password)) {
+					return next(Boom.unauthorized());
+				}
+
+				// Build a viewer JWT and sign it
+				const jwt = {
+					channel: channelId,
+					platform: platformId,
+					viewer: viewer.email,
+					audience: ['platform']
+				};
+
+				return this.bus.query({role: 'identity', cmd: 'sign'}, jwt);
+			})
+			.then(jwt => {
+				// Attach the JWT to the viewer and respond for a successful login
+				viewer.jwt = jwt;
+
+				// Scrub the password from the viewer before responding
+				delete viewer.password;
+
+				res.body = viewer;
+				res.status(200);
+				return next();
+			})
+			.catch(next);
+	}
+
+	static create(spec) {
+		if (!spec.bus || !_.isObject(spec.bus)) {
+			throw new Error('IdentityLoginController spec.bus is required');
+		}
+
+		return Controller.create(new IdentityLoginController(spec));
+	}
+}
+
+module.exports = IdentityLoginController;

--- a/lib/services/identity/controllers/identity-login-controller.js
+++ b/lib/services/identity/controllers/identity-login-controller.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const bcrypt = require('bcrypt');
+const superagent = require('superagent');
 const Boom = require('boom');
 
 const Controller = require('../../../controllers/controller');
@@ -14,10 +15,7 @@ class IdentityLoginController {
 	}
 
 	post(req, res, next) {
-		const payload = _.cloneDeep(req.body || {});
 		const channelId = (req.identity.channel || {}).id;
-		const platformId = (req.identity.platform || {}).id;
-		let viewer;
 
 		return controller.postFetchChannel({req, next, bus: this.bus})
 			.then(channel => {
@@ -25,40 +23,9 @@ class IdentityLoginController {
 					return next(Boom.conflict(`Channel ${channelId} does not exist.`));
 				}
 
-				// Fetch the viewer by channel and id (email)
-				const args = {
-					id: payload.email,
-					type: 'viewer',
-					channel: channelId
-				};
-
-				return this.bus.query({role: 'store', cmd: 'get', type: 'viewer'}, args);
+				return (channel.features.authentication.url) ? proxyAuth(this.bus, req, res, next) : nativeAuth(this.bus, req, res, next);
 			})
-			.then(resource => {
-				viewer = resource;
-
-				// Verify the password is correct
-				if (!bcrypt.compareSync(payload.password, viewer.password)) {
-					return next(Boom.unauthorized());
-				}
-
-				// Build a viewer JWT and sign it
-				const jwt = {
-					channel: channelId,
-					platform: platformId,
-					viewer: viewer.email,
-					audience: ['platform']
-				};
-
-				return this.bus.query({role: 'identity', cmd: 'sign'}, jwt);
-			})
-			.then(jwt => {
-				// Attach the JWT to the viewer and respond for a successful login
-				viewer.jwt = jwt;
-
-				// Scrub the password from the viewer before responding
-				delete viewer.password;
-
+			.then(viewer => {
 				res.body = viewer;
 				res.status(200);
 				return next();
@@ -76,3 +43,90 @@ class IdentityLoginController {
 }
 
 module.exports = IdentityLoginController;
+
+function proxyAuth(bus, req, res, next) {
+	let viewer;
+	let proxyJWT;
+
+	return superagent
+		.post(req.identity.channel.features.authentication.url)
+		.send(req.body)
+		.then(response => {
+			if (!res.ok) {
+				return next(Boom.unauthorized());
+			}
+
+			proxyJWT = response.body.attributes.jwt;
+			const args = {
+				id: req.body.payload.email,
+				type: 'viewer',
+				channel: req.identity.channel.id
+			};
+
+			return bus.query({role: 'store', cmd: 'get', type: 'viewer'}, args);
+		})
+		.then(resource => {
+			viewer = resource;
+			const jwt = {
+				channel: req.identity.channel.id,
+				platform: req.identity.platform.id,
+				viewer: req.body.payload.email,
+				audience: ['platform']
+			};
+
+			// Store the proxy's JWT on the viewer meta for re-auth later and save the viewer
+			viewer.meta.jwt = proxyJWT;
+			bus.sendCommand({role: 'store', cmd: 'set', type: 'viewer'}, viewer);
+
+			return bus.query({role: 'identity', cmd: 'sign'}, jwt);
+		})
+		.then(jwt => {
+			// Attach the JWT to the viewer and respond for a successful login
+			viewer.jwt = jwt;
+
+			// Scrub the password from the viewer before responding
+			delete viewer.password;
+
+			return viewer;
+		});
+}
+
+function nativeAuth(bus, req, res, next) {
+	let viewer;
+
+	// Fetch the viewer by channel and id (email)
+	const args = {
+		id: req.body.payload.email,
+		type: 'viewer',
+		channel: req.identity.channel.id
+	};
+
+	return bus.query({role: 'store', cmd: 'get', type: 'viewer'}, args)
+		.then(resource => {
+			viewer = resource;
+
+			// Verify the password is correct
+			if (!bcrypt.compareSync(req.body.payload.password, viewer.password)) {
+				return next(Boom.unauthorized());
+			}
+
+			// Build a viewer JWT and sign it
+			const jwt = {
+				channel: req.identity.channel.id,
+				platform: req.identity.platform.id,
+				viewer: req.body.payload.email,
+				audience: ['platform']
+			};
+
+			return bus.query({role: 'identity', cmd: 'sign'}, jwt);
+		})
+		.then(jwt => {
+			// Attach the JWT to the viewer and respond for a successful login
+			viewer.jwt = jwt;
+
+			// Scrub the password from the viewer before responding
+			delete viewer.password;
+
+			return viewer;
+		});
+}

--- a/lib/services/identity/index.js
+++ b/lib/services/identity/index.js
@@ -8,6 +8,7 @@ const initializeQueries = require('./queries/');
 const IdentityItemController = require('./controllers/identity-item-controller');
 const IdentityListController = require('./controllers/identity-list-controller');
 const IdentityConfigController = require('./controllers/identity-config-controller');
+const IdentityLoginController = require('./controllers/identity-login-controller');
 
 module.exports = function (bus, options) {
 	debug('initializing');
@@ -83,6 +84,14 @@ module.exports = function (bus, options) {
 				IdentityItemController.create({bus, type})
 			);
 		});
+
+		router.all(
+			'/login',
+			middleware['request-authorize']({bus, audience: {
+				post: ['platform']
+			}}),
+			IdentityLoginController.create({bus})
+		);
 
 		router.all(
 			'/config',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "object-property-natural-sort": "0.0.4",
     "oddcast": "~2.1.0",
     "redis-search": "~0.0.1",
-    "reds": "^0.2.5"
+    "reds": "^0.2.5",
+    "superagent": "^2.3.0"
   },
   "devDependencies": {
     "aws-sdk": "~2.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/oddnetworks/oddworks",
   "dependencies": {
+    "bcrypt": "^0.8.7",
     "bluebird": "~3.4.0",
     "body-parser": "~1.15.0",
     "boom": "~4.0.0",


### PR DESCRIPTION
Single login route for now.

```
POST /login

{
  "type": "login",
  "attributes": {
    "email": "blain.smith@oddnetworks.com",
    "password": "12345"
  }
}
```

Responds with 401 or 200

```
{
  "id": "blain.smith@oddnetworks.com",
  "attributes": {
    "jwt:" "NEW VIEWER JWT",
    "entitlements": ['gold']
  }
  "relationships": {...}
}
```