### PR TITLE
Testing remove

### DIFF
--- a/lib/stores/memory/index.js
+++ b/lib/stores/memory/index.js
@@ -110,6 +110,30 @@ module.exports = function (bus, options) {
 		};
 	}
 
+	function createRemover(type) {
+		return function remove(args) {
+			args = args || {};
+			if (!args.id || !_.isString(args.id)) {
+				return Promise.reject(new Error('args.id String is required.'));
+			}
+			if (!args.channel || !_.isString(args.channel)) {
+				return Promise.reject(new Error('args.channel String is required.'));
+			}
+
+			const channel = args.channel;
+			const id = args.id;
+
+			const scope = CACHE[channel] || Object.create(null);
+			const table = scope[type] || Object.create(null);
+
+			if (table[id]) {
+				delete table[id];
+				return Promise.resolve(true);
+			}
+			return Promise.resolve(false);
+		};
+	}
+
 	function getChannel(args) {
 		args = args || {};
 		if (!args.id || !_.isString(args.id)) {
@@ -214,6 +238,10 @@ module.exports = function (bus, options) {
 		// payload - Object
 		// payload.channel - String *required*
 		bus.commandHandler({role: 'store', cmd: 'set', type}, createSetter(type));
+
+		// args.channel - String *required*
+		// args.id - String *required*
+		bus.commandHandler({role: 'store', cmd: 'remove', type}, createRemover(type));
 	});
 
 	// Everything is different for the "channel" type

--- a/spec/stores/dynamodb-spec.js
+++ b/spec/stores/dynamodb-spec.js
@@ -1,4 +1,4 @@
-/* global xdescribe, describe, beforeAll, it, expect */
+/* global describe, beforeAll, it, expect */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
@@ -618,8 +618,55 @@ describe('DynamoDB Store', function () {
 		});
 	});
 
-	xdescribe('cmd:remove', function () {
-		it('should be tested');
+	describe('cmd:remove', function () {
+		const RESULTS = {
+			GET_BEFORE: null,
+			GET_AFTER: null
+		};
+
+		const entities = _.range(3).map(n => {
+			return {title: `identity-${n}`, channel: 'oddnews'};
+		});
+
+		const type = 'video';
+		const channel = 'oddnews';
+
+		beforeAll(function (done) {
+			Promise.resolve(entities)
+				.then(entities => {
+					const cmd = 'set';
+					return Promise.all(entities.map(entity => {
+						return bus.sendCommand({role, cmd, type}, entity);
+					}));
+				})
+				.then(() => {
+					return bus.query({role, cmd: 'scan', type}, {channel});
+				})
+				.then(res => {
+					RESULTS.GET_BEFORE = res;
+					return res;
+				})
+				.then(() => {
+					const video = RESULTS.GET_BEFORE[0];
+					// the memory store doesn't seem to have a remove command
+					return bus.sendCommand({role, cmd: 'remove', type}, {id: video.id, channel});
+				})
+				.then(() => {
+					return bus.query({role, cmd: 'scan', type}, {channel});
+				})
+				.then(res => {
+					RESULTS.GET_AFTER = res;
+					return res;
+				})
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('should remove an item', function (done) {
+			expect(RESULTS.GET_BEFORE.length).toBe(3);
+			expect(RESULTS.GET_AFTER.length).toBe(2);
+			done();
+		});
 	});
 
 	describe('cmd:scan', function () {

--- a/spec/stores/memory-spec.js
+++ b/spec/stores/memory-spec.js
@@ -1,4 +1,4 @@
-/* global xdescribe, describe, beforeAll, it, expect */
+/* global describe, beforeAll, it, expect, xit */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
@@ -547,8 +547,55 @@ describe('Memory Store', function () {
 		});
 	});
 
-	xdescribe('cmd:remove', function () {
-		it('should be tested');
+	describe('cmd:remove', function () {
+		const RESULTS = {
+			GET_BEFORE: null,
+			GET_AFTER: null
+		};
+
+		const entities = _.range(3).map(n => {
+			return {title: `identity-${n}`, channel: 'oddnews'};
+		});
+
+		const type = 'video';
+		const channel = 'oddnews';
+
+		beforeAll(function (done) {
+			Promise.resolve(entities)
+				.then(entities => {
+					const cmd = 'set';
+					return Promise.all(entities.map(entity => {
+						return bus.sendCommand({role, cmd, type}, entity);
+					}));
+				})
+				.then(() => {
+					return bus.query({role, cmd: 'scan', type}, {channel});
+				})
+				.then(res => {
+					RESULTS.GET_BEFORE = res;
+					return res;
+				})
+				.then(() => {
+					const video = RESULTS.GET_BEFORE[0];
+					// the memory store doesn't seem to have a remove command
+					return bus.sendCommand({role, cmd: 'remove', type}, {id: video.id, channel});
+				})
+				.then(() => {
+					return bus.query({role, cmd: 'scan', type}, {channel});
+				})
+				.then(res => {
+					RESULTS.GET_AFTER = res;
+					return res;
+				})
+				.then(done)
+				.catch(done.fail);
+		});
+
+		xit('should remove an item', function (done) {
+			expect(RESULTS.GET_BEFORE.length).toBe(3);
+			expect(RESULTS.GET_AFTER.length).toBe(2);
+			done();
+		});
 	});
 
 	describe('cmd:scan', function () {

--- a/spec/stores/memory-spec.js
+++ b/spec/stores/memory-spec.js
@@ -1,4 +1,4 @@
-/* global describe, beforeAll, it, expect, xit */
+/* global describe, beforeAll, it, expect */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
@@ -591,7 +591,7 @@ describe('Memory Store', function () {
 				.catch(done.fail);
 		});
 
-		xit('should remove an item', function (done) {
+		it('should remove an item', function (done) {
 			expect(RESULTS.GET_BEFORE.length).toBe(3);
 			expect(RESULTS.GET_AFTER.length).toBe(2);
 			done();

--- a/spec/stores/redis-spec.js
+++ b/spec/stores/redis-spec.js
@@ -1,4 +1,4 @@
-/* global xdescribe, describe, beforeAll, it, expect */
+/* global describe, beforeAll, it, expect */
 /* eslint prefer-arrow-callback: 0 */
 /* eslint-disable max-nested-callbacks */
 'use strict';
@@ -552,8 +552,54 @@ describe('Redis Store', function () {
 		});
 	});
 
-	xdescribe('cmd:remove', function () {
-		it('should be tested');
+	describe('cmd:remove', function () {
+		const RESULTS = {
+			GET_BEFORE: null,
+			GET_AFTER: null
+		};
+
+		const entities = _.range(3).map(n => {
+			return {title: `identity-${n}`, channel: 'oddnews'};
+		});
+
+		const type = 'video';
+		const channel = 'oddnews';
+
+		beforeAll(function (done) {
+			Promise.resolve(entities)
+				.then(entities => {
+					const cmd = 'set';
+					return Promise.all(entities.map(entity => {
+						return bus.sendCommand({role, cmd, type}, entity);
+					}));
+				})
+				.then(() => {
+					return bus.query({role, cmd: 'scan', type}, {channel});
+				})
+				.then(res => {
+					RESULTS.GET_BEFORE = res;
+					return res;
+				})
+				.then(() => {
+					const video = RESULTS.GET_BEFORE[0];
+					return bus.sendCommand({role, cmd: 'remove', type}, {id: video.id, channel});
+				})
+				.then(() => {
+					return bus.query({role, cmd: 'scan', type}, {channel});
+				})
+				.then(res => {
+					RESULTS.GET_AFTER = res;
+					return res;
+				})
+				.then(done)
+				.catch(done.fail);
+		});
+
+		it('should remove an item', function (done) {
+			expect(RESULTS.GET_BEFORE.length).toBe(3);
+			expect(RESULTS.GET_AFTER.length).toBe(2);
+			done();
+		});
 	});
 
 	describe('cmd:scan', function () {


### PR DESCRIPTION
There used to be Three outstanding tests in the test suite.

Now there is only one left.  

Why?  After creating the test for the memory store, the test failed.  Then I found that it looks like the Memory store doesn't have a 'remove' command yet.

Should the 'remove' command be created for the memory store?

-Al