### PR TITLE
Override Cache-Control

### DIFF
--- a/lib/middleware/response-cache-control.js
+++ b/lib/middleware/response-cache-control.js
@@ -13,7 +13,7 @@ module.exports = function (options) {
 	].join(', ');
 
 	return function responseCacheControl(req, res, next) {
-		res.set('Cache-Control', header);
+		res.set('Cache-Control', res.get('Cache-Control') || header);
 
 		if (options.surrogateKey) {
 			res.set('Surrogate-Key', composeSurrogateKey(req, res));

--- a/spec/middleware/response-cache-control-spec.js
+++ b/spec/middleware/response-cache-control-spec.js
@@ -27,6 +27,14 @@ describe('Middleware: Response Cache Control', () => {
 		});
 	});
 
+	it('allows route-level overrides', () => {
+		res.set('Cache-Control', 'private'); // Do not cache
+
+		responseCacheControl()(req, res, () => {
+			expect(res.get('Cache-Control')).toBe('private');
+		});
+	});
+
 	it('adds Surrogate Key header for single resource', () => {
 		res.body = {id: 'resource-id', type: 'resource-type'};
 


### PR DESCRIPTION
The `Cache-Control` header can not be overridden to tell client what to do with the content. Within any route or middleware mounted **before** `response-cache-control` middleware you can set `res.set('Cache-Control', 'private');` to cause it never to expire. You can also set standard properties of `Cache-Control` if you just wanted to lower or raise the max age, etc.

More on the Cache Control header https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control