### PR TITLE
Errors on includes

### DIFF
--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -183,7 +183,55 @@ module.exports = function (options) {
 			res.body = {};
 
 			if (_.isString(req.query.include)) {
-				res.body.included = composeIncluded(req.query.include, data, baseUrl);
+				// make a single object with all of the relationships of the requested entities
+				const toInclude = req.query.include.split(',');
+				let allRelationships = [];
+				toInclude.map(type => {
+					allRelationships = allRelationships.concat((data.relationships[type] || {}).data);
+					return type;
+				});
+
+				const allowPartialIncluded = Boolean(options.allowPartialIncluded);
+				const allRelationshipsPresent = (data.included || []).length === (allRelationships || []).length;
+
+				if (allowPartialIncluded || allRelationshipsPresent) {
+					res.body.included = composeIncluded(req.query.include, data, baseUrl);
+				} else {
+					// send back an errors array
+					res.body = {
+						errors: [
+							{
+								code: '500',
+								source: {pointer: req.url},
+								title: 'Internal Server Error',
+								detail: 'Root resource references missing relationship(s)'
+							}
+						]
+					};
+					allRelationships.map(item => {
+						// if this item is not in successfully retrieved data.included
+						if (!_.some(data.included, {id: item.id})) {
+							const missingItem = {
+								code: '410',
+								title: 'Gone',
+								detail: `No ${item.type || 'resource'} with id ${item.id || ''}`,
+								meta: {
+									identifier: {
+										id: item.id,
+										type: item.type
+									}
+								}
+							};
+							// include in the error message
+							res.body.errors.push(missingItem);
+							return missingItem;
+						}
+						return null;
+					});
+
+					// stop adding things to the response
+					return next();
+				}
 			}
 
 			delete data.included;

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -211,7 +211,7 @@ describe('Middleware Response JSON API', function () {
 			req = _.cloneDeep(REQ);
 			req.query = {include: 'entities,video'};
 			res = new MockExpressResponse();
-			middleware = responseJsonApi({bus});
+			middleware = responseJsonApi({bus, allowPartialIncluded: true});
 
 			return Promise.resolve(null)
 				// Load seed data
@@ -281,7 +281,7 @@ describe('Middleware Response JSON API', function () {
 			req = _.cloneDeep(REQ);
 			req.query = {include: 'entities,video'};
 			res = new MockExpressResponse();
-			middleware = responseJsonApi({bus});
+			middleware = responseJsonApi({bus, allowPartialIncluded: true});
 
 			brokenCollection = _.cloneDeep(COLLECTION);
 			brokenCollection.id = _.uniqueId('broken-collection-');
@@ -364,7 +364,7 @@ describe('Middleware Response JSON API', function () {
 		};
 
 		beforeAll(function (done) {
-			middleware = responseJsonApi({bus});
+			middleware = responseJsonApi({bus, allowPartialIncluded: true});
 			resources = _.range(14).map(resourceFactory);
 
 			req = _.cloneDeep(REQ);
@@ -430,7 +430,8 @@ describe('Middleware Response JSON API', function () {
 			res = new MockExpressResponse();
 			middleware = responseJsonApi({
 				bus,
-				baseUrlPrefix: '/v2'
+				baseUrlPrefix: '/v2',
+				allowPartialIncluded: true
 			});
 
 			return Promise.resolve(null)
@@ -488,7 +489,8 @@ describe('Middleware Response JSON API', function () {
 			res = new MockExpressResponse();
 			middleware = responseJsonApi({
 				bus,
-				excludePortFromLinks: true
+				excludePortFromLinks: true,
+				allowPartialIncluded: true
 			});
 
 			return Promise.resolve(null)
@@ -535,10 +537,15 @@ describe('Middleware Response JSON API', function () {
 		});
 	});
 
-	describe('with partial included resourses present', function () {
+	describe('with partial included resourses', function () {
 		let req = null;
 		let res = null;
 		let middleware = null;
+		const RESULTS = {
+			INITIAL_GET: null,
+			ERRORS: null,
+			SUCCESS: null
+		};
 
 		beforeAll(function (done) {
 			req = _.cloneDeep(REQ);
@@ -546,28 +553,44 @@ describe('Middleware Response JSON API', function () {
 			res = new MockExpressResponse();
 			middleware = responseJsonApi({bus});
 
+			const role = 'store';
+			const cmd = 'get';
+			const type = 'collection';
+
+			const args = {
+				channel: 'channel-id',
+				type,
+				id: COLLECTION_1.id,
+				platform: 'platform-id',
+				include: ['entities']
+			};
+
+			req.url = `/${type}s/${COLLECTION_1.id}?include=entities`;
+
 			return Promise.resolve(null)
 				// Load seed data (without using include)
 				.then(() => {
-					const role = 'store';
-					const cmd = 'get';
-					const type = 'collection';
-
-					const args = {
-						channel: 'channel-id',
-						type,
-						id: COLLECTION_1.id,
-						platform: 'platform-id',
-						include: ['entities']
-					};
-
 					return bus.query({role, cmd, type}, args).then(result => {
 						// console.log('RESULT:  ', JSON.stringify(result, ' ', 2));
 						res.body = result;
+						RESULTS.INITIAL_GET = _.cloneDeep(res);
+						return res;
 					});
 				})
 				.then(() => {
 					return middleware(req, res, err => {
+						RESULTS.ERRORS = _.cloneDeep(res);
+						if (err) {
+							return done.fail(err);
+						}
+						return null;
+					});
+				})
+				.then(() => {
+					const middleware2 = responseJsonApi({bus, allowPartialIncluded: true});
+					res = RESULTS.INITIAL_GET;
+					return middleware2(req, res, err => {
+						RESULTS.SUCCESS = _.cloneDeep(res);
 						if (err) {
 							return done.fail(err);
 						}
@@ -578,19 +601,36 @@ describe('Middleware Response JSON API', function () {
 				.then(done)
 				.catch(done.fail);
 		});
+		describe('and partial results NOT allowed', function () {
+			it('formats response body to valid jsonapi.org schema', function () {
+				const body = RESULTS.ERRORS.body;
+				const v = Validator.validate(body, jsonApiSchema);
+				expect(v.valid).toBe(true);
+			});
 
-		it('formats response body to valid jsonapi.org schema', function () {
-			const v = Validator.validate(res.body, jsonApiSchema);
-			expect(v.valid).toBe(true);
+			it('has missing items in the errors array', function () {
+				const body = RESULTS.ERRORS.body;
+				expect(body.errors).toBeTruthy();
+				expect(body.errors.length).toBe(8);
+			});
 		});
 
-		it('has only present entities in the included array', function () {
-			// console.log('RES.BODY:  ', JSON.stringify(res.body, ' ', 2));
-			// console.log('INCLUDED:  ', JSON.stringify(res.body.included, ' ', 2));
-			// console.log('ENTITIES.DATA:  ', JSON.stringify(res.body.data.relationships.entities.data, ' ', 2));
-			expect(res.body.included).toBeDefined();
-			expect(res.body.included.length).toBe(3);
-			expect(res.body.included.length).toBe(res.body.data.relationships.entities.data.length);
+		describe('and partial results ARE allowed', function () {
+			it('formats response body to valid jsonapi.org schema', function () {
+				const body = RESULTS.SUCCESS.body;
+				const v = Validator.validate(body, jsonApiSchema);
+				expect(v.valid).toBe(true);
+			});
+
+			it('has only present entities in the included array', function () {
+				const body = RESULTS.SUCCESS.body;
+				// console.log('RES.BODY:  ', JSON.stringify(res.body, ' ', 2));
+				// console.log('INCLUDED:  ', JSON.stringify(res.body.included, ' ', 2));
+				// console.log('ENTITIES.DATA:  ', JSON.stringify(res.body.data.relationships.entities.data, ' ', 2));
+				expect(body.included).toBeDefined();
+				expect(body.included.length).toBe(3);
+				expect(body.included.length).toBe(body.data.relationships.entities.data.length);
+			});
 		});
 	});
 


### PR DESCRIPTION
Issue #160 Came to a new conclusion.  These changes should satisfy the root of these.
- for `response-jsonapi`, there is a new config option called `options.allowPartialIncluded`
    - if true -> a query with `?includes=foo` that has some missing references will respond with only the entities that are present in the db
    - if false -> the response is a valid jsonapi errors response with the 1st error reporting on the main issue, and the following errors reports on the entities missing from the db
- Alters the tests that were using collections with missing entities to use `options.allowPartialIncluded: true`
- Adds a test for the returned errors array when `options.allowPartialIncluded` is false

NOTE - a similar response should come from relationships endpoint.  That should probably get it's own endpoint.