### PR TITLE
Config Sans JWT

### DIFF
--- a/lib/services/identity/controllers/identity-config-controller.js
+++ b/lib/services/identity/controllers/identity-config-controller.js
@@ -1,8 +1,6 @@
 'use strict';
 
-const Promise = require('bluebird');
 const _ = require('lodash');
-const uuid = require('node-uuid');
 
 const Controller = require('../../../controllers/controller');
 
@@ -15,31 +13,9 @@ class IdentityConfigController extends Controller {
 	get(req, res, next) {
 		const channel = req.identity.channel;
 		const platform = req.identity.platform;
-		let viewer = req.identity.viewer;
 
 		return this.bus
-			.query({role: 'identity', cmd: 'config'}, {channel, platform, viewer})
-			.then(resource => {
-				// Return the config right away if requesting it with a viewer-JWT OR authentication is enabled
-				if (viewer || _.get(channel, 'features.authentication.enabled', false)) {
-					return resource;
-				}
-
-				// Create the viewer if none exists.
-				const id = uuid.v4();
-				viewer = {id, channel: channel.id, type: 'viewer'};
-				const payload = {channel: channel.id, platform: platform.id, viewer: id, audience: ['platform']};
-
-				return Promise.join(
-					this.bus.sendCommand({role: 'store', cmd: 'set', type: 'viewer'}, viewer),
-					this.bus.query({role: 'identity', cmd: 'sign'}, payload),
-					(viewer, jwt) => {
-						resource.viewer = viewer;
-						resource.jwt = jwt;
-						return resource;
-					}
-				);
-			})
+			.query({role: 'identity', cmd: 'config'}, {channel, platform})
 			.then(resource => {
 				if (_.has(resource, 'features.authentication.proxy')) {
 					delete resource.features.authentication.proxy;

--- a/lib/services/identity/queries/index.js
+++ b/lib/services/identity/queries/index.js
@@ -164,7 +164,6 @@ module.exports = function (service) {
 		const omittedKeys = [
 			'id',
 			'type',
-			'viewer',
 			'channel',
 			'platform',
 			'updatedAt',
@@ -180,7 +179,6 @@ module.exports = function (service) {
 
 		config.channel = channel.id;
 		config.platform = platform.id;
-		config.viewer = args.viewer || null;
 		return Promise.resolve(config);
 	};
 


### PR DESCRIPTION
The JWT will not be coming down in the config anymore. This served no valid in the content services. Event services will be smart enough to handle the replacement logic.