### PR TITLE
Fix Proxy Response Error

### DIFF
--- a/lib/services/identity/controllers/identity-login-controller.js
+++ b/lib/services/identity/controllers/identity-login-controller.js
@@ -45,6 +45,7 @@ class IdentityLoginController {
 
 				return loginPromise;
 			})
+			.then(buildViewerJWT(this.bus, req))
 			.then(viewer => {
 				res.body = viewer;
 				res.status(200);
@@ -129,8 +130,7 @@ function proxyLogin(bus, req, res, next) {
 				_.get(proxyResponse, 'body.data.meta.jwt', '')
 			);
 			return bus.sendCommand({role: 'store', cmd: 'set', type: 'viewer'}, viewer);
-		})
-		.then(buildViewerJWT(bus, req, res, next));
+		});
 }
 
 function nativeLogin(bus, req, res, next) {
@@ -149,8 +149,7 @@ function nativeLogin(bus, req, res, next) {
 			}
 
 			return viewer;
-		})
-		.then(buildViewerJWT(bus, req, res, next));
+		});
 }
 
 function buildViewerJWT(bus, req) {

--- a/lib/services/identity/controllers/identity-login-controller.js
+++ b/lib/services/identity/controllers/identity-login-controller.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const bcrypt = require('bcrypt');
 const superagent = require('superagent');
+const Promise = require('bluebird');
 const Boom = require('boom');
 
 const Controller = require('../../../controllers/controller');
@@ -30,17 +31,16 @@ class IdentityLoginController {
 				let loginPromise;
 
 				if (_.has(channel, 'features.authentication.proxy')) {
-					loginPromise = proxyLogin(this.bus, req, res, next);
+					loginPromise = proxyLogin(this.bus, req);
 				} else if (_.has(channel, 'features.authentication.evaluators')) {
 					try {
 						const loginEvaluator = eval(`(${channel.features.authentication.evaluators.login})`); // eslint-disable-line no-eval
-						loginPromise = loginEvaluator(this.bus, req, res, next).then(buildViewerJWT(this.bus, req, res, next));
+						loginPromise = loginEvaluator(this.bus, req);
 					} catch (err) {
-						console.log(err.stack);
 						return next(Boom.wrap(err));
 					}
 				} else {
-					loginPromise = nativeLogin(this.bus, req, res, next);
+					loginPromise = nativeLogin(this.bus, req);
 				}
 
 				return loginPromise;
@@ -51,7 +51,13 @@ class IdentityLoginController {
 				res.status(200);
 				return next();
 			})
-			.catch(next);
+			.catch(err => {
+				if (err.status) {
+					return next(Boom.create(err.status));
+				}
+
+				return next(err);
+			});
 	}
 
 	static create(spec) {
@@ -65,7 +71,7 @@ class IdentityLoginController {
 
 module.exports = IdentityLoginController;
 
-function proxyLogin(bus, req, res, next) {
+function proxyLogin(bus, req) {
 	let viewer;
 	let proxyResponse;
 
@@ -84,7 +90,7 @@ function proxyLogin(bus, req, res, next) {
 		.send(body)
 		.then(response => {
 			if (!response.ok) {
-				return next(Boom.unauthorized());
+				return Promise.reject(response);
 			}
 
 			proxyResponse = response;
@@ -133,7 +139,7 @@ function proxyLogin(bus, req, res, next) {
 		});
 }
 
-function nativeLogin(bus, req, res, next) {
+function nativeLogin(bus, req) {
 	// Fetch the viewer by channel and id (email)
 	const args = {
 		id: req.body.email,
@@ -145,7 +151,7 @@ function nativeLogin(bus, req, res, next) {
 		.then(viewer => {
 			// Verify the password is correct
 			if (!bcrypt.compareSync(req.body.password, viewer.password)) {
-				return next(Boom.unauthorized());
+				return Promise.reject(Boom.unauthorized());
 			}
 
 			return viewer;

--- a/spec/services/identity/controllers/identity-login-controller-spec.js
+++ b/spec/services/identity/controllers/identity-login-controller-spec.js
@@ -99,7 +99,11 @@ describe('Identity Service Controller', function () {
 				evaluators: {
 					login: `function (bus, req, res, next) {
 						return new Promise(function (resolve, reject) {
-							if (req.body.email === 'viewer999@oddnetworks.com') {
+							if (req.body.email === '401') {
+								reject({status: 401});
+							} else if (req.body.email === '503') {
+								reject({status: 503});
+							} else if (req.body.email === 'viewer999@oddnetworks.com') {
 								const viewer = {
 									id: 'viewer999@oddnetworks.com',
 									type: 'viewer',
@@ -284,7 +288,7 @@ describe('Identity Service Controller', function () {
 			};
 
 			this.controller.login.post(req, res, err => {
-				expect(err).toBeDefined();
+				expect(err.output.statusCode).toBe(401);
 				done();
 			});
 		});
@@ -311,6 +315,46 @@ describe('Identity Service Controller', function () {
 				expect(res.body.entitlements.length).toBe(1);
 				expect(res.body.jwt).toBeDefined();
 				expect(res.body.meta.source).toBe('evaluator');
+				done();
+			});
+		});
+
+		it('replies with a 401 if invalid login', function (done) {
+			const req = {
+				identity: {
+					channel: CHANNEL_EVALUATORS,
+					platform: PLATFORM
+				},
+				body: {
+					type: 'authentication',
+					email: '401',
+					password: ''
+				}
+			};
+
+			this.controller.login.post(req, res, err => {
+				expect(err.isBoom).toBe(true);
+				expect(err.output.statusCode).toBe(401);
+				done();
+			});
+		});
+
+		it('replies with a 503 from upstream server', function (done) {
+			const req = {
+				identity: {
+					channel: CHANNEL_EVALUATORS,
+					platform: PLATFORM
+				},
+				body: {
+					type: 'authentication',
+					email: '503',
+					password: ''
+				}
+			};
+
+			this.controller.login.post(req, res, err => {
+				expect(err.isBoom).toBe(true);
+				expect(err.output.statusCode).toBe(503);
 				done();
 			});
 		});


### PR DESCRIPTION
Errors were getting thrown to the console while responding to devices with a 500. Now any upstream proxy errors get propagated up the promise chain and returned to the devices. So a 401 from the upstream auth server will be a 401 to the device.