### PR TITLE
Updates to response meta and pagination on list endpoints

### DIFF
--- a/lib/middleware/response-json-api.js
+++ b/lib/middleware/response-json-api.js
@@ -138,8 +138,6 @@ module.exports = function (options) {
 			baseUrl = `${baseUrl}${BASE_PREFIX}`;
 		}
 
-		const meta = _.cloneDeep(res.body.meta);
-
 		let data;
 
 		if (isRelationshipRoute(req)) {
@@ -247,18 +245,20 @@ module.exports = function (options) {
 			res.body.links = res.body.data.links;
 		}
 
-		res.body.meta = meta || {};
+		const meta = _.cloneDeep(res.body.meta);
+		res.body.meta = Object.assign({}, meta, _.get(res, 'meta'));
 
-		if (req.identity) {
-			if (req.identity.channel) {
-				res.body.meta.channel = req.identity.channel.id;
-			}
-			if (req.identity.platform) {
-				res.body.meta.platform = req.identity.platform.id;
-			}
+		if (_.has(req, 'identity')) {
+			res.body.meta.channel = _.get(req, 'identity.channel.id');
+			res.body.meta.platform = _.get(req, 'identity.platform.id');
 		}
 
-		// Add request query strings to meta.query, controllers can override them and set defaults if they choose to
+		if (_.has(req, 'query.include')) {
+			req.query.include = req.query.include.split(',');
+		}
+
+		// Add request query strings to meta.query,
+		// controllers can override them and set defaults if they choose to
 		if (req.query) {
 			res.body.meta.query = req.query;
 		}

--- a/lib/services/catalog/controllers/catalog-list-controller.js
+++ b/lib/services/catalog/controllers/catalog-list-controller.js
@@ -16,7 +16,14 @@ class CatalogListController extends Controller {
 		const type = this.type;
 		const platform = req.identity.platform;
 		const viewer = req.identity.viewer;
-		const limit = parseInt(req.query.limit, 10) || 10;
+		// default to a result set limit of 10
+		// default ot a result set offset of 0
+		const pagination = {
+			offset: parseInt(_.get(req, 'query.offset', 0), 10),
+			limit: parseInt(_.get(req, 'query.limit', 10), 10)
+		};
+		req.query.offset = pagination.offset;
+		req.query.limit = pagination.limit;
 
 		if (!platform && !this.isAdminRequest(req)) {
 			return next(Boom.badRequest(
@@ -26,7 +33,7 @@ class CatalogListController extends Controller {
 
 		return this.getChannel(req)
 			.then(channel => {
-				const args = {type, limit};
+				const args = {type, limit: pagination.limit};
 
 				// When no platform ID is present in the JWT during an admin role request,
 				// the query for the resource is made directly to the store instead of through
@@ -41,9 +48,20 @@ class CatalogListController extends Controller {
 				args.viewer = viewer;
 				return this.bus.query({role: 'catalog', cmd: 'fetchItemList'}, args);
 			})
-			.then(resources => {
+			.then(data => {
 				res.status(200);
-				res.body = resources.slice(0, limit);
+				const total = data.length;
+
+				// Pagination
+				if (data.length > 0) {
+					const start = pagination.offset;
+					const end = start + pagination.limit;
+					data = data.slice(start, end);
+				}
+
+				res.body = data;
+				const count = res.body.length;
+				res.meta = Object.assign({}, res.meta, {total, count});
 				next();
 				return null;
 			})

--- a/lib/services/catalog/controllers/catalog-search-controller.js
+++ b/lib/services/catalog/controllers/catalog-search-controller.js
@@ -64,8 +64,8 @@ class CatalogSearchController extends Controller {
 						data = data.reverse();
 					}
 				}
-
-				if (data.length > 0) {
+				const total = data.length;
+				if (total > 0) {
 					const start = req.query.offset;
 					let end = data.length;
 					if (req.query.limit) {
@@ -73,6 +73,8 @@ class CatalogSearchController extends Controller {
 					}
 					data = data.slice(start, end);
 				}
+				const count = data.length;
+				res.meta = Object.assign({}, res.meta, {total, count});
 
 				res.status(200);
 				res.body = data;

--- a/spec/middleware/response-json-api-spec.js
+++ b/spec/middleware/response-json-api-spec.js
@@ -155,7 +155,7 @@ describe('Middleware Response JSON API', function () {
 		});
 
 		it('adds a meta block', function () {
-			expect(res.body.meta).toEqual({extra: 'info', channel: 'channel-id', platform: 'platform-id'});
+			expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'platform-id'});
 		});
 	});
 
@@ -169,6 +169,11 @@ describe('Middleware Response JSON API', function () {
 			res = mockExpressResponse();
 			middleware = responseJsonApi({bus});
 			req.url = 'https://localhost:3000/collections';
+			req.query = {
+				offset: 0,
+				limit: null,
+				sort: null
+			};
 
 			return Promise.resolve(null)
 				// Load seed data (without using include)
@@ -187,6 +192,7 @@ describe('Middleware Response JSON API', function () {
 
 					return bus.query({role, cmd, type}, args).then(result => {
 						res.body = result;
+						res.meta = {total: result.length, count: result.length};
 					});
 				})
 				.then(() => {
@@ -209,6 +215,17 @@ describe('Middleware Response JSON API', function () {
 
 		it('has no included array', function () {
 			expect(res.body.included).not.toBeDefined();
+		});
+
+		it('has response metadata about result set', function () {
+			expect(res.body.meta.count).toBe(3);
+			expect(res.body.meta.total).toBe(3);
+		});
+
+		it('has response metadata about query parameters', function () {
+			expect(res.body.meta.query.offset).toBe(0);
+			expect(res.body.meta.query.limit).toBe(null);
+			expect(res.body.meta.query.sort).toBe(null);
 		});
 	});
 
@@ -278,7 +295,7 @@ describe('Middleware Response JSON API', function () {
 		});
 
 		it('adds a meta block', function () {
-			expect(res.body.meta).toEqual({extra: 'info', channel: 'channel-id', platform: 'platform-id', query: {include: 'entities,video'}});
+			expect(res.body.meta).toEqual({channel: 'channel-id', platform: 'platform-id', query: {include: ['entities', 'video']}});
 		});
 	});
 
@@ -379,15 +396,15 @@ describe('Middleware Response JSON API', function () {
 			resources = _.range(14).map(resourceFactory);
 
 			req = _.cloneDeep(REQ);
-			req.url = `/collections?${querystring.stringify({'page[limit]': 14, 'page[offset]': 0})}`;
+			req.url = `/collections?${querystring.stringify({limit: 14, offset: 0})}`;
 
 			res = mockExpressResponse();
 
 			res.body = resources;
 			res.body.linksQueries = {
 				next: {
-					'page[limit]': 10,
-					'page[offset]': 11
+					limit: 14,
+					offset: 15
 				}
 			};
 
@@ -413,20 +430,20 @@ describe('Middleware Response JSON API', function () {
 
 		it('sets the resource self link', function () {
 			const links = res.body.links;
-			expect(links.self).toBe('https://example.com:3000/collections?page%5Blimit%5D=14&page%5Boffset%5D=0');
+			expect(links.self).toBe('https://example.com:3000/collections?limit=14&offset=0');
 			const urlObject = url.parse(links.self);
 			const query = querystring.parse(urlObject.query);
-			expect(query['page[limit]']).toBe('14');
-			expect(query['page[offset]']).toBe('0');
+			expect(query.limit).toBe('14');
+			expect(query.offset).toBe('0');
 		});
 
 		it('sets the resource next link', function () {
 			const links = res.body.links;
-			expect(links.next).toBe('https://example.com:3000/collections?page%5Blimit%5D=10&page%5Boffset%5D=11');
+			expect(links.next).toBe('https://example.com:3000/collections?limit=14&offset=15');
 			const urlObject = url.parse(links.next);
 			const query = querystring.parse(urlObject.query);
-			expect(query['page[limit]']).toBe('10');
-			expect(query['page[offset]']).toBe('11');
+			expect(query.limit).toBe('14');
+			expect(query.offset).toBe('15');
 		});
 	});
 


### PR DESCRIPTION
Note: true `meta.total` on catalog-list-controller isn't currently possible with store implementation.