### PR TITLE
Request Verify Throttling

### DIFF
--- a/lib/middleware/request-verify.js
+++ b/lib/middleware/request-verify.js
@@ -30,34 +30,42 @@ module.exports = function (options) {
 		const viewer = req.identity.viewer;
 
 		if (viewer) {
-			let verifyEvaluator = yes;
-			try {
-				debug('using evaluator from `channel.features.authentication.evaluators.verify`');
+			const timestamp = Date.now();
+			const expires = _.get(viewer, 'meta.internal.expires', timestamp);
 
-				verifyEvaluator = eval(`(${channel.features.authentication.evaluators.verify})`); // eslint-disable-line no-eval
-			} catch (err) {
-				debug('verify-evaluator-eval-error: %s', err.message);
-				debug('verify-evaluator-eval-error: defaulting to false');
-				bus.broadcast(
-					{level: 'warn', event: 'verify-evaluator-eval-error'},
-					{message: err.message, error: err}
-				);
+			if (timestamp >= expires) {
+				let verifyEvaluator = yes;
+				try {
+					debug('using evaluator from `channel.features.authentication.evaluators.verify`');
 
-				verifyEvaluator = no(err.message);
+					verifyEvaluator = eval(`(${channel.features.authentication.evaluators.verify})`); // eslint-disable-line no-eval
+				} catch (err) {
+					debug('verify-evaluator-eval-error: %s', err.message);
+					debug('verify-evaluator-eval-error: defaulting to false');
+					bus.broadcast(
+						{level: 'warn', event: 'verify-evaluator-eval-error'},
+						{message: err.message, error: err}
+					);
+
+					verifyEvaluator = no(err.message);
+				}
+
+				// Run the evaluator and pass or fail it
+				verifyEvaluator(bus, req, res)
+					.then(() => {
+						return next();
+					})
+					.catch(err => {
+						if (err.status) {
+							return next(Boom.create(err.status));
+						}
+
+						return next(err);
+					});
+			} else {
+				debug('viewer has not expired, skipping');
+				return next();
 			}
-
-			// Run the evaluator and pass or fail it
-			verifyEvaluator(bus, req, res)
-				.then(() => {
-					return next();
-				})
-				.catch(err => {
-					if (err.status) {
-						return next(Boom.create(err.status));
-					}
-
-					return next(err);
-				});
 		} else {
 			debug('requesting without a viewer JWT, skipping');
 			return next();

--- a/lib/services/identity/index.js
+++ b/lib/services/identity/index.js
@@ -173,7 +173,6 @@ module.exports = function (bus, options) {
 			middleware['request-authorize']({bus, audience: {
 				get: ['platform', 'admin']
 			}}),
-			middleware['request-verify']({bus}),
 			IdentityConfigController.create({bus})
 		);
 

--- a/spec/middleware/request-verify-spec.js
+++ b/spec/middleware/request-verify-spec.js
@@ -36,6 +36,24 @@ describe('Middleware: Request Verify', () => {
 		});
 	});
 
+	it('bypasses verify when viewer has not expired', done => {
+		req.identity.viewer.meta = {
+			internal: {
+				expires: Date.now() + 10000
+			}
+		};
+
+		res.body.data = {
+			id: 'some-video',
+			meta: {}
+		};
+
+		requestVerify({bus})(req, res, function (err) {
+			expect(err).toBeUndefined();
+			done();
+		});
+	});
+
 	it('does not verify when evaluator fails', done => {
 		req.identity.channel.features.authentication.evaluators = {
 			verify: `function (bus, req, res) {


### PR DESCRIPTION
Only verifies if the viewer expires when `meta.internal.expires` is set. These are set on the login and verify evaluators so they are custom.