### PR TITLE
exposes channel controllers on the identity service

### DIFF
--- a/lib/services/identity/index.js
+++ b/lib/services/identity/index.js
@@ -33,7 +33,9 @@ module.exports = function (bus, options) {
 		IdentityItemController,
 		IdentityConfigController,
 		IdentityLoginController,
-		ViewerRelationshipController
+		ViewerRelationshipController,
+		IdentityChannelsListController,
+		IdentityChannelController
 	};
 
 	const queries = initializeQueries(service);


### PR DESCRIPTION
Specific methods for POST and PATCH of a channel were separated from the identity-item and identity-list controllers and refactored into channel specific controllers.

This PR exposes the controllers on the identity service so they can be used in custom implementations.

-Al