### PR TITLE
spec.sync to bypass provider sync

### DIFF
--- a/lib/services/catalog/commands/index.js
+++ b/lib/services/catalog/commands/index.js
@@ -104,9 +104,9 @@ module.exports = function (service) {
 
 		// Set a true promise as a default to bypass sync
 		let promise = Promise.resolve(true);
-		
-		// If spec: true then reassign promise to run a sync through the provider
-		if (spec.sync) {
+
+		// If sync: true then reassign promise to run a sync through the provider
+		if (sync) {
 			promise = service.bus
 				.query({role: 'provider', cmd: 'get', source}, {object, spec})
 				.then(sourceObject => {
@@ -138,7 +138,7 @@ module.exports = function (service) {
 					return Promise.reject(Boom.resourceGone(
 						'Resource for specification was not fetched from the provider'
 					));
-				})
+				});
 		}
 
 		// Run the promise and finally store the spec in the db

--- a/lib/services/catalog/commands/index.js
+++ b/lib/services/catalog/commands/index.js
@@ -79,10 +79,14 @@ module.exports = function (service) {
 		if (!spec.source || !_.isString(spec.source)) {
 			throw new Error('spec.source String is required');
 		}
+		if (spec.sync && !_.isBoolean(spec.sync)) {
+			throw new Error('spec.sync is not Boolean');
+		}
 
 		const channel = spec.channel;
 		const source = spec.source;
 		const type = spec.type;
+		const sync = spec.sync || true;
 		const objectType = type.replace(/Spec$/, '');
 		let object = {channel, type: objectType};
 		let objectId;
@@ -98,38 +102,47 @@ module.exports = function (service) {
 			objectId = `res-${id}`;
 		}
 
-		return service.bus
-			.query({role: 'provider', cmd: 'get', source}, {object, spec})
-			.then(sourceObject => {
-				if (sourceObject) {
-					object = _.cloneDeep(sourceObject);
-					object.channel = channel;
-					object.type = objectType;
-					object.id = objectId;
-					object.spec = specId;
+		// Set a true promise as a default to bypass sync
+		let promise = Promise.resolve(true);
+		
+		// If spec: true then reassign promise to run a sync through the provider
+		if (spec.sync) {
+			promise = service.bus
+				.query({role: 'provider', cmd: 'get', source}, {object, spec})
+				.then(sourceObject => {
+					if (sourceObject) {
+						object = _.cloneDeep(sourceObject);
+						object.channel = channel;
+						object.type = objectType;
+						object.id = objectId;
+						object.spec = specId;
 
-					return service.bus.sendCommand(
-						{role: 'catalog', cmd: 'setItem'},
-						object
-					);
-				}
+						return service.bus.sendCommand(
+							{role: 'catalog', cmd: 'setItem'},
+							object
+						);
+					}
 
-				// Remove the spec and object if the source does not exist.
-				if (spec.id) {
-					service.bus.sendCommand(
-						{role: 'catalog', cmd: 'removeItemSpec'},
-						spec
-					);
-					service.bus.sendCommand(
-						{role: 'catalog', cmd: 'removeItem'},
-						object
-					);
-				}
+					// Remove the spec and object if the source does not exist.
+					if (spec.id) {
+						service.bus.sendCommand(
+							{role: 'catalog', cmd: 'removeItemSpec'},
+							spec
+						);
+						service.bus.sendCommand(
+							{role: 'catalog', cmd: 'removeItem'},
+							object
+						);
+					}
 
-				return Promise.reject(Boom.resourceGone(
-					'Resource for specification was not fetched from the provider'
-				));
-			})
+					return Promise.reject(Boom.resourceGone(
+						'Resource for specification was not fetched from the provider'
+					));
+				})
+		}
+
+		// Run the promise and finally store the spec in the db
+		return promise
 			.then(() => {
 				spec.id = specId;
 				spec.channel = channel;


### PR DESCRIPTION
By default setting a spec will always run a sync with the provider, but you can bypass it by setting a spec with sync: false to just store the spec in the db.