### PR TITLE
passes the full query from the search endpoint to the underlying store

### DIFF
--- a/lib/services/catalog/controllers/catalog-search-controller.js
+++ b/lib/services/catalog/controllers/catalog-search-controller.js
@@ -15,6 +15,7 @@ class CatalogSearchController extends Controller {
 
 	get(req, res, next) {
 		const query = _.get(req, 'query.q', '');
+		const fullQuery = _.get(req, 'query', {});
 		const channel = (req.identity.channel || {}).id;
 		const viewer = req.identity.viewer;
 
@@ -47,7 +48,12 @@ class CatalogSearchController extends Controller {
 			return next(Boom.badRequest('`limit` query parameter must be greater then 1'));
 		}
 
-		const args = {query, channel, types: req.query.types};
+		const args = {
+			query,
+			channel,
+			types: req.query.types,
+			fullQuery
+		};
 
 		return this.bus.query({role: 'catalog', cmd: 'search'}, args)
 			.then(data => {


### PR DESCRIPTION
There are times when the underlying search store may want or need more params from the query other than just the search term.