### PR TITLE
Catch bus.sendCommand() errors and emit as warning events.

### DIFF
--- a/lib/services/catalog/commands/index.js
+++ b/lib/services/catalog/commands/index.js
@@ -57,7 +57,13 @@ module.exports = function (service) {
 		service.bus.sendCommand(
 			{role: 'store', cmd: 'remove', type: spec.type},
 			spec
-		);
+		).catch(err => {
+			service.bus.broadcast(
+				{level: 'warn', event: 'error-role-store-cmd-remove'},
+				{message: err.message, error: err}
+			);
+			return null;
+		});
 
 		return service.bus
 			.sendCommand({role: 'store', cmd: 'remove', type}, args)
@@ -119,11 +125,23 @@ module.exports = function (service) {
 					service.bus.sendCommand(
 						{role: 'catalog', cmd: 'removeItemSpec'},
 						spec
-					);
+					).catch(err => {
+						service.bus.broadcast(
+							{level: 'warn', event: 'error-role-catalog-cmd-removeItemSpec'},
+							{message: err.message, error: err}
+						);
+						return null;
+					});
 					service.bus.sendCommand(
 						{role: 'catalog', cmd: 'removeItem'},
 						object
-					);
+					).catch(err => {
+						service.bus.broadcast(
+							{level: 'warn', event: 'error-role-catalog-cmd-removeItem'},
+							{message: err.message, error: err}
+						);
+						return null;
+					});
 				}
 
 				return Promise.reject(Boom.resourceGone(
@@ -169,7 +187,13 @@ module.exports = function (service) {
 		service.bus.sendCommand(
 			{role: 'store', cmd: 'remove', type: object.type},
 			object
-		);
+		).catch(err => {
+			service.bus.broadcast(
+				{level: 'warn', event: 'error-role-store-cmd-remove'},
+				{message: err.message, error: err}
+			);
+			return null;
+		});
 
 		return service.bus
 			.sendCommand({role: 'store', cmd: 'remove', type}, args)

--- a/lib/stores/redis-search/index.js
+++ b/lib/stores/redis-search/index.js
@@ -107,12 +107,24 @@ module.exports = function (bus, options) {
 					bus.sendCommand(
 						{role: 'store', cmd: 'index', type: resource.type},
 						{id: resource.id, text}
-					);
+					).catch(err => {
+						bus.broadcast(
+							{level: 'warn', event: 'error-role-store-cmd-index'},
+							{message: err.message, error: err}
+						);
+						return null;
+					});
 				} else {
 					bus.sendCommand(
 						{role: 'store', cmd: 'deindex', type: resource.type},
 						{id: resource.id}
-					);
+					).catch(err => {
+						bus.broadcast(
+							{level: 'warn', event: 'error-role-store-cmd-deindex'},
+							{message: err.message, error: err}
+						);
+						return null;
+					});
 				}
 			});
 
@@ -122,7 +134,13 @@ module.exports = function (bus, options) {
 				bus.sendCommand(
 					{role: 'store', cmd: 'deindex', type: resource.type},
 					{id: resource.id}
-				);
+				).catch(err => {
+					bus.broadcast(
+						{level: 'warn', event: 'error-role-store-cmd-deindex'},
+						{message: err.message, error: err}
+					);
+					return null;
+				});
 			});
 		}
 	});

--- a/lib/stores/reds/index.js
+++ b/lib/stores/reds/index.js
@@ -109,12 +109,24 @@ module.exports = function (bus, options) {
 					bus.sendCommand(
 						{role: 'store', cmd: 'index', type: resource.type},
 						{id: resource.id, text}
-					);
+					).catch(err => {
+						bus.broadcast(
+							{level: 'warn', event: 'error-role-store-cmd-index'},
+							{message: err.message, error: err}
+						);
+						return null;
+					});
 				} else {
 					bus.sendCommand(
 						{role: 'store', cmd: 'deindex', type: resource.type},
 						{id: resource.id}
-					);
+					).catch(err => {
+						bus.broadcast(
+							{level: 'warn', event: 'error-role-store-cmd-deindex'},
+							{message: err.message, error: err}
+						);
+						return null;
+					});
 				}
 			});
 
@@ -124,7 +136,13 @@ module.exports = function (bus, options) {
 				bus.sendCommand(
 					{role: 'store', cmd: 'deindex', type: resource.type},
 					{id: resource.id}
-				);
+				).catch(err => {
+					bus.broadcast(
+						{level: 'warn', event: 'error-role-store-cmd-deindex'},
+						{message: err.message, error: err}
+					);
+					return null;
+				});
 			});
 		}
 	});


### PR DESCRIPTION
If we don't return the promise result of bus.sendCommand(), any
potential errors will be lost forever in the land of asychrony and
promises. A better way with "send and forget" actions which return a
promise, like bus.sendCommand(), is to `.catch()` any potential errors
and emit them for any listeners who might be interested.

 Changes to be committed:
	modified:   lib/services/catalog/commands/index.js
	modified:   lib/stores/redis-search/index.js
	modified:   lib/stores/reds/index.js